### PR TITLE
Fix: 스타일 타입 지정 및 확장 / Feat: Home => Survey 라우터 설정 및 타입 추가

### DIFF
--- a/src/Pages/Home.tsx
+++ b/src/Pages/Home.tsx
@@ -42,7 +42,7 @@ const Home = () => {
           <div className="flex items-center justify-center w-48 h-48 bg-white rounded-full">
             <span className="text-2xl font-bold">Logo</span>
           </div>
-          <Button label="로그인 없이 시작" type="button" {...mainButtonArgs} />
+          <Button label="로그인 없이 시작" type="button" {...mainButtonArgs} onClick={() => navigate('/survey')}/>
         </section>
         <section className="flex flex-col items-center p-8 space-y-4 bg-[#e9e7e2] rounded-lg">
           <section>

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -14,6 +14,7 @@ export interface StyleProps {
 export interface ButtonProps extends StyleProps{
   label: string;
   type?: "submit" | "button";
+  onClick?: () => void
 }
 
 const Button = styled.button<

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,15 +1,19 @@
 import React from "react";
 import styled from "styled-components";
 
-export interface ButtonProps {
-  label: string;
-  type?: "submit" | "button";
+
+export interface StyleProps {
   backgroundColor?: "#A860F6" | "#D1D5DB" | "#facc15" | "#10B981" | "white";
   hoverColor?: "#D4B7F4" | "#E5E7EB" | "#fde047" | "#34D399" | "#F4F5F7";
   textColor?: "white" | "#374151";
   width?: "12rem" | "16rem" | "4rem";
   height?: "3rem" | "4rem";
   textSize?: "1rem";
+}
+
+export interface ButtonProps extends StyleProps{
+  label: string;
+  type?: "submit" | "button";
 }
 
 const Button = styled.button<

--- a/src/components/ButtonArgs.ts
+++ b/src/components/ButtonArgs.ts
@@ -1,4 +1,8 @@
-export const mainButtonArgs = {
+import { StyleProps } from "./Button";
+
+
+
+export const mainButtonArgs: StyleProps = {
   backgroundColor: "#A860F6",
   hoverColor: "#D4B7F4",
   textColor: "white",
@@ -7,7 +11,7 @@ export const mainButtonArgs = {
   textSize: "1rem",
 };
 
-export const authButtonArgs = {
+export const authButtonArgs: StyleProps = {
   backgroundColor: "#D1D5DB",
   hoverColor: "#E5E7EB",
   textColor: "#374151",
@@ -16,7 +20,7 @@ export const authButtonArgs = {
   textSize: "1rem",
 };
 
-export const kakaoButtonArgs = {
+export const kakaoButtonArgs: StyleProps = {
   backgroundColor: "#facc15",
   hoverColor: "#fde047",
   textColor: "#374151",
@@ -25,7 +29,7 @@ export const kakaoButtonArgs = {
   textSize: "1rem",
 };
 
-export const naverButtonArgs = {
+export const naverButtonArgs: StyleProps = {
   backgroundColor: "#10B981",
   hoverColor: "#34D399",
   textColor: "#374151",
@@ -34,7 +38,7 @@ export const naverButtonArgs = {
   textSize: "1rem",
 };
 
-export const googleButtonArgs = {
+export const googleButtonArgs: StyleProps = {
   backgroundColor: "white",
   hoverColor: "#F4F5F7",
   textColor: "#374151",


### PR DESCRIPTION
## 📝작업 내용

> 버튼 타입 에러가 발생해서 타입을 분리하고 확장했습니다.
> ButtonArgs에 타입을 지정해주지 않아서 생긴 에러로 StyleProps라는 타입을 지정하고 ButtonProps에 type과 label을 확장해서 넣어주었습니다.
> Home에서 '로그인 없이 시작' 클릭 시 survey로 이동하게 지정했습니다. 그에 따른 Button에 onClick 타입도 지정해주었습니다.