### PR TITLE
Feat: survey => result ai 요청 결과 불러오기 / Fix: Loading.tsx 컴포넌트 함수 표현식으로 변경

### DIFF
--- a/src/Pages/Result.tsx
+++ b/src/Pages/Result.tsx
@@ -1,8 +1,17 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import Button from "../components/Button";
 import { mainButtonArgs } from "../components/ButtonArgs";
+import { useLocation } from "react-router-dom";
 
 const Result = () => {
+  const location = useLocation();
+  const [imageUrl, setImageUrl] = useState()
+
+  useEffect(() => {
+    const { url } = location.state
+    setImageUrl(url)
+  }, []);
+
   return (
     <div className="flex flex-col md:flex-row items-center justify-center min-h-screen bg-bg">
       <div className="flex flex-col items-center px-4 space-y-4 max-w-lg">
@@ -10,7 +19,7 @@ const Result = () => {
         <h2 className="font-bold text-2xl">마법사 유령</h2>
         <div>
           <img
-            src="/images/ideal-image.png"
+            src={imageUrl}
             alt="이상형 이미지"
             className="rounded-lg"
           />

--- a/src/Pages/Survey.tsx
+++ b/src/Pages/Survey.tsx
@@ -1,38 +1,38 @@
 import React, { useState, useEffect } from "react";
 import { surveyContentsMen, surveyContentsWomen, genderTheme } from "../components/Survey";
+import { imageGenerate } from "../services/imageGenerator";
+import { useLocation, useNavigate } from "react-router-dom";
 
 type Gender = "남자" | "여자"
 
 const Survey = () => {
+  const navigate = useNavigate()
   const [selectedGender, setSelectedGender] = useState<Gender | null>(null);
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState<number>(0);
   const [responses, setResponses] = useState<string[]>([]);
-  // 성별에 따른 현재 설문내용 선언
   const currentSurvey =
     selectedGender === "남자" ? surveyContentsMen : surveyContentsWomen;
+  
 
-  // 성별 선택 핸들러
   const handleGenderSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
     const gender = event.target.value as Gender;
     setSelectedGender(gender);
   };
 
-  // 옵션 선택 핸들러
   const handleOptionChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setResponses((prev) => prev.concat(event.target.value))
-    // setResponses((prev) => [...prev, event.target.value]
     setCurrentQuestionIndex(currentQuestionIndex + 1);
-    // 옵션을 선택하면 자동으로 다음 페이지로 넘어가기
   };
 
    useEffect(() => {
     if (currentQuestionIndex === currentSurvey.length) {
       const handleConfirm = () => {
-        const confirmSubmit = confirm("응답을 제출하시겠습니까?");
+        const confirmSubmit = confirm("제출하시겠습니까?");
+        
         if (confirmSubmit) {
           handleSubmit();
         }else{
-          // 예외처리
+          alert("요청이 잘못 되었습니다.")
         }
       };
 
@@ -40,9 +40,20 @@ const Survey = () => {
     }
   }, [currentQuestionIndex]);
 
-  // 응답 제출 핸들러 (제출하는 코드 추가해야 함)
-  const handleSubmit = () => {
-    console.log("응답내용 : ", responses);
+  interface imageUrl {
+      data: {
+        url: string
+    }[]
+  }
+
+  const handleSubmit = async () => {
+    try{
+      const response = await imageGenerate(responses)
+      const imageUrl = response?.data[0]?.url
+      navigate('/result', {state: { url: imageUrl}})
+    }catch(error){
+      console.log(error)
+    }
   };
 
   return (

--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-export default function Loading() {
+export const Loading = () => {
   return (
     <div>
       <img src="/images/spin.gif" alt="loading" width="10%" />
@@ -9,3 +9,5 @@ export default function Loading() {
     </div>
   );
 }
+
+export default Loading

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,9 +8,9 @@ const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
 );
 root.render(
-  <React.StrictMode>
+  // <React.StrictMode>
     <App />
-  </React.StrictMode>
+  // </React.StrictMode>
 );
 
 reportWebVitals();

--- a/src/services/imageGenerator.tsx
+++ b/src/services/imageGenerator.tsx
@@ -4,12 +4,12 @@ export const maxDuration = 300;
 export const dynamic = 'force-dynamic';
 
 const openai = new OpenAI({
-  apiKey: "API_KEY_", // env에 추가
+  apiKey: process.env.REACT_APP_OPEN_AI_API_KEY,
   dangerouslyAllowBrowser: true
 });
 
-export async function imageGenerate() {
-  const prompt = "남자 20대 170cm이상 70kg이상 숏컷 무쌍 너무 밝지도 어둡지도 않은 자연스러운 피부색을 가진 증명사진을 그려줘";
+export async function imageGenerate(order: string[]) {
+  const prompt = "realistic" + order.join(' ')
 
   try {
     const response = await openai.images.generate({
@@ -19,8 +19,7 @@ export async function imageGenerate() {
       size: '1024x1024',
     });
 
-    // Response를 콘솔에 출력
-    console.log(response);
+    return response
 
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
## 📝작업 내용

> survey 페이지에서 설문조사 한 정보들을 토대로 AI 요청을 보내고 불러오기 기능을 구현했습니다.
> Loading.tsx 컴포넌트가 선언문으로 되어있어 표현식으로 변경했습니다.

## 💬리뷰 요구사항

> 요청이 대략 13초정도 걸리는데, setTimeout을 15초 정도로 해도 좋을 것 같아요!
> 내일은 survey를 변경해서 좀 더 실사적으로 이미지를 뽑아보죠 