### PR TITLE
Feat: 생성 이미지 storage 업로드

### DIFF
--- a/src/Pages/Result.tsx
+++ b/src/Pages/Result.tsx
@@ -2,15 +2,33 @@ import React, { useEffect, useState } from "react";
 import Button from "../components/Button";
 import { mainButtonArgs } from "../components/ButtonArgs";
 import { useLocation } from "react-router-dom";
+import { uploadImageToFirebase } from "../services/uploadImage";
 
 const Result = () => {
   const location = useLocation();
-  const [imageUrl, setImageUrl] = useState()
+  const [imageUrl, setImageUrl] = useState("");
+  const [downloadUrl, setDownloadUrl] = useState("");
 
   useEffect(() => {
-    const { url } = location.state
-    setImageUrl(url)
+    const { url } = location.state;
+    setImageUrl(url);
   }, []);
+
+  // 로그인 인증에 따른 user 받아오는거 추가 예정
+  useEffect(() => {
+    const handleUpload = async () => {
+      const userId = "userID1234";
+      try {
+        if (imageUrl.trim() !== "") {
+          const url = await uploadImageToFirebase(imageUrl, userId);
+          setDownloadUrl(url);
+        }
+      } catch (error) {
+        console.error("Error uploading image: ", error);
+      }
+    };
+    handleUpload();
+  }, [imageUrl]);
 
   return (
     <div className="flex flex-col md:flex-row items-center justify-center min-h-screen bg-bg">
@@ -18,11 +36,7 @@ const Result = () => {
         <h4 className="text-gray">당신의 이상형은:</h4>
         <h2 className="font-bold text-2xl">마법사 유령</h2>
         <div>
-          <img
-            src={imageUrl}
-            alt="이상형 이미지"
-            className="rounded-lg"
-          />
+          <img src={imageUrl} alt="이상형 이미지" className="rounded-lg" />
         </div>
       </div>
       <div className="flex flex-col items-center px-4 space-y-4 md:space-y-8 max-w-lg">
@@ -35,9 +49,17 @@ const Result = () => {
         </p>
         <Button label="로그인" type="submit" {...mainButtonArgs} />
         <div>
-          <button className="size-8 mr-6">
-            <img src="/images/icon-photo.png" alt="사진저장 아이콘" />
-          </button>
+          {/* 로그인 인증에 따른 코드 추가 필요 */}
+          {downloadUrl && (
+            <button
+              onClick={() => {
+                window.open(downloadUrl);
+              }}
+              className="size-8 mr-6"
+            >
+              <img src="/images/icon-photo.png" alt="사진저장 아이콘" />
+            </button>
+          )}
           <button className="size-8">
             <img src="/images/icon-share.png" alt="공유 아이콘" />
           </button>

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,6 +1,7 @@
 import { initializeApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
 import { getFirestore, collection } from "firebase/firestore";
+import { getStorage } from "firebase/storage";
 
 const firebaseConfig = {
   // .env.local에 추가
@@ -18,3 +19,4 @@ const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 export const db = getFirestore(app);
 export const USERS_COLLECTION = collection(db, "users");
+export const storage = getStorage(app);

--- a/src/services/uploadImage.ts
+++ b/src/services/uploadImage.ts
@@ -1,0 +1,25 @@
+import React from "react";
+import { ref, uploadBytes, getDownloadURL } from "firebase/storage";
+import { storage } from "../firebase";
+
+export const uploadImageToFirebase = async (
+  imageUrl: string,
+  userId: string,
+) => {
+  try {
+    // 생성된 이미지 url을 사용해 이미지 다운로드
+    const response = await fetch(imageUrl);
+    const blob = await response.blob();
+
+    // 다운로드한 이미지를 Firebase Storage에 업로드
+    const storageRef = ref(storage, `images/${userId}.jpg`);
+    await uploadBytes(storageRef, blob);
+
+    // 업로드된 이미지의 다운로드 url 가져오기
+    const downloadUrl = await getDownloadURL(storageRef);
+    return downloadUrl;
+  } catch (error) {
+    console.error("Error uploading image to Firebase:", error);
+    throw error;
+  }
+};


### PR DESCRIPTION
## 📝작업 내용

> 결과 페이지에서 imageUrl을 받아서 storage에 업로드하고 접근할 수 있는 downloadUrl을 리턴하고 있습니다.

## 💬리뷰 요구사항(선택)

> 비회원 사용자와 회원 사용자 모두를 고려한다면 firestore + storage 둘 다 사용하는 것이 적절한 저장소를 제공할 수 있다고 판단됐고, 로그인 한 경우 firestore에 downloadUrl을 저장하는 것은 완료되는 대로 올리겠습니다.