### PR TITLE
Fix: CORS오류 proxy로 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "idealtype",
   "version": "0.1.0",
   "private": true,
+  "proxy": "https://oaidalleapiprodscus.blob.core.windows.net",
   "dependencies": {
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",

--- a/src/services/uploadImage.ts
+++ b/src/services/uploadImage.ts
@@ -7,6 +7,7 @@ export const uploadImageToFirebase = async (
   userId: string,
 ) => {
   try {
+    imageUrl = imageUrl.replace('https://oaidalleapiprodscus.blob.core.windows.net', '');
     // 생성된 이미지 url을 사용해 이미지 다운로드
     const response = await fetch(imageUrl);
     const blob = await response.blob();


### PR DESCRIPTION
## #️⃣연관된 이슈

> #48 

## 📝작업 내용

> Proxy로 CORS오류를 해결했습니다
> Proxy로 이미지 도메인을 지정하고 이미지 url을 해당 도메인만큼 문자열에서 지워주었습니다
> 결과로 proxy는 잘되어 업로드가 잘 되는 것을 확인했습니다 


## 💬리뷰 요구사항

> vercel은 따로 지정해줘야 합니다
> @sennydayk 세연님 배포시에 vercel.json 생성하셔서 복붙하시면 될 겁니다!

```json
// vercel.json
{
    "rewrites": [
      {
        "source": "/api/:path*",
        "destination": "https://oaidalleapiprodscus.blob.core.windows.net/:path*"
      }
    ]
  }
```