### PR TITLE
Fix: React props Warning 제거

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -3,12 +3,12 @@ import styled from "styled-components";
 
 
 export interface StyleProps {
-  backgroundColor?: "#A860F6" | "#D1D5DB" | "#facc15" | "#10B981" | "white";
-  hoverColor?: "#D4B7F4" | "#E5E7EB" | "#fde047" | "#34D399" | "#F4F5F7";
-  textColor?: "white" | "#374151";
+  $backgroundColor?: "#A860F6" | "#D1D5DB" | "#facc15" | "#10B981" | "white";
+  $hoverColor?: "#D4B7F4" | "#E5E7EB" | "#fde047" | "#34D399" | "#F4F5F7";
+  $textColor?: "white" | "#374151";
   width?: "12rem" | "16rem" | "4rem";
   height?: "3rem" | "4rem";
-  textSize?: "1rem";
+  $textSize?: "1rem";
 }
 
 export interface ButtonProps extends StyleProps{
@@ -20,23 +20,23 @@ export interface ButtonProps extends StyleProps{
 const Button = styled.button<
   Pick<
     ButtonProps,
-    | "backgroundColor"
-    | "hoverColor"
-    | "textColor"
+    | "$backgroundColor"
+    | "$hoverColor"
+    | "$textColor"
     | "width"
     | "height"
-    | "textSize"
+    | "$textSize"
   >
 >`
-  background-color: ${(props) => props.backgroundColor || "#007BFF"};
-  color: ${(props) => props.textColor || "white"};
-  font-size: ${(props) => props.textSize || "1rem"};
+  background-color: ${(props) => props.$backgroundColor || "#007BFF"};
+  color: ${(props) => props.$textColor || "white"};
+  font-size: ${(props) => props.$textSize || "1rem"};
   width: ${(props) => props.width || "12rem"};
   height: ${(props) => props.height || "3rem"};
   padding: 0.5rem 1rem;
   border-radius: 0.375rem;
   &:hover {
-    background-color: ${(props) => props.hoverColor};
+    background-color: ${(props) => props.$hoverColor};
   }
 `;
 

--- a/src/components/ButtonArgs.ts
+++ b/src/components/ButtonArgs.ts
@@ -3,46 +3,46 @@ import { StyleProps } from "./Button";
 
 
 export const mainButtonArgs: StyleProps = {
-  backgroundColor: "#A860F6",
-  hoverColor: "#D4B7F4",
-  textColor: "white",
+  $backgroundColor: "#A860F6",
+  $hoverColor: "#D4B7F4",
+  $textColor: "white",
   width: "12rem",
   height: "3rem",
-  textSize: "1rem",
+  $textSize: "1rem",
 };
 
 export const authButtonArgs: StyleProps = {
-  backgroundColor: "#D1D5DB",
-  hoverColor: "#E5E7EB",
-  textColor: "#374151",
+  $backgroundColor: "#D1D5DB",
+  $hoverColor: "#E5E7EB",
+  $textColor: "#374151",
   width: "16rem",
   height: "3rem",
-  textSize: "1rem",
+  $textSize: "1rem",
 };
 
 export const kakaoButtonArgs: StyleProps = {
-  backgroundColor: "#facc15",
-  hoverColor: "#fde047",
-  textColor: "#374151",
+  $backgroundColor: "#facc15",
+  $hoverColor: "#fde047",
+  $textColor: "#374151",
   width: "4rem",
   height: "4rem",
-  textSize: "1rem",
+  $textSize: "1rem",
 };
 
 export const naverButtonArgs: StyleProps = {
-  backgroundColor: "#10B981",
-  hoverColor: "#34D399",
-  textColor: "#374151",
+  $backgroundColor: "#10B981",
+  $hoverColor: "#34D399",
+  $textColor: "#374151",
   width: "4rem",
   height: "4rem",
-  textSize: "1rem",
+  $textSize: "1rem",
 };
 
 export const googleButtonArgs: StyleProps = {
-  backgroundColor: "white",
-  hoverColor: "#F4F5F7",
-  textColor: "#374151",
+  $backgroundColor: "white",
+  $hoverColor: "#F4F5F7",
+  $textColor: "#374151",
   width: "4rem",
   height: "4rem",
-  textSize: "1rem",
+  $textSize: "1rem",
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> #58 

## 📝작업 내용

> styled-components로 prop을 내릴때 생기는 경고로 DOM이 해당 값을 읽을 수 없다고 합니다.
> prefix '$'을 앞에 붙여 해당 porp을 styled-components 내에서만 사용하게 합니다. 

### 스크린샷
![image](https://github.com/what-is-your-ideal-type/FE_what-is-your-ideal-type/assets/105287510/b8e02e05-7b03-4783-aa86-51a99413ac56)


## 💬리뷰 요구사항

> 경고만 있는거지만, 후에 Light House 점수에 영향을 미칠 수 있다고 생각해 조치를 취했는데 괜찮을까요? @sennydayk 님이 작성하신 props라 컨펌 해서 머지해주시면 됩니다.