### PR TITLE
Update: 이미지 저장(로그인, 비로그인 구분해서 저장) / Feat: myPage에서 해당 유저의 firebase 이미지 보여주기

### DIFF
--- a/src/Pages/MyPage.tsx
+++ b/src/Pages/MyPage.tsx
@@ -1,32 +1,73 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import Loading from "../components/Loading";
 import Button from "../components/Button";
 import { mainButtonArgs } from "../components/ButtonArgs";
+import { auth, IMAGES_COLLECTION } from "../firebase";
+import {
+  query,
+  getDocs,
+  QuerySnapshot,
+  DocumentData,
+} from "firebase/firestore";
+import { onAuthStateChanged } from "firebase/auth";
+
+interface CardData {
+  url: string;
+  createdAt: Date;
+}
 
 const MyPage = () => {
+  const [cards, setCards] = useState<CardData[]>([]);
+  const [uid, setUid] = useState<string | null>(null);
+  useEffect(() => {
+    onAuthStateChanged(auth, (user) => {
+      if (user) {
+        setUid(user.uid);
+      } else {
+        // 로그인 해주세요.
+      }
+    });
+  }, []);
+
+  useEffect(() => {
+    if (uid !== null) {
+      const q = query(IMAGES_COLLECTION(uid));
+      getDocs(q).then((querySnapshot: QuerySnapshot<DocumentData>) => {
+        const newCards: CardData[] = [];
+        console.log("querySnapshot", querySnapshot);
+        querySnapshot.forEach((doc) => {
+          const data = doc.data();
+          const cardData: CardData = {
+            url: data.url,
+            createdAt: data.createdAt.toDate(),
+          };
+          newCards.push(cardData);
+        });
+        setCards((prevCards) => [...prevCards, ...newCards]);
+      });
+    } else {
+      // 로그인 해주세요.
+    }
+  }, [uid]);
+
   return (
     <main className="flex flex-col items-center space-y-8 bg-bg py-16">
       <h1 className="text-3xl font-bold">Josh님의 이상형 리스트 입니다.</h1>
       <Button label="새로운 이상형 찾기" type="button" {...mainButtonArgs} />
       <section className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
-        {Array(4)
-          .fill(0)
-          .map((_, index) => (
-            <div key={index} className="w-[250px]">
-              <div className="p-4">
-                <img
-                  src="/images/image 13.png"
-                  alt="차은우"
-                  className="w-full h-auto"
-                />
-                <div className="mt-4 space-y-1 text-center">
-                  <p>#차가운 #만찢남/여</p>
-                  <p>#20대 #오독한 코</p>
-                  <p>#하얀 피부 #키 180이상</p>
-                </div>
+        {cards.map((card, index) => (
+          <div key={index} className="w-[250px]">
+            <div className="p-4">
+              <img src={card.url} alt="차은우" className="w-full h-auto" />
+              <div className="mt-4 space-y-1 text-center">
+                <p>#차가운 #만찢남/여</p>
+                <p>#20대 #오독한 코</p>
+                <p>#하얀 피부 #키 180이상</p>
+                <b>{card.createdAt.toLocaleDateString()}</b>
               </div>
             </div>
-          ))}
+          </div>
+        ))}
       </section>
     </main>
   );

--- a/src/Pages/Result.tsx
+++ b/src/Pages/Result.tsx
@@ -3,35 +3,36 @@ import Button from "../components/Button";
 import { mainButtonArgs } from "../components/ButtonArgs";
 import { uploadImageToFirebase } from "../services/uploadImage";
 import { useParams } from "react-router-dom";
+import { auth } from "../firebase";
 
 const Result = () => {
-  const { prompts, url } = useParams()
+  const { prompts, url } = useParams();
   const [imageUrl, setImageUrl] = useState("");
   const [downloadUrl, setDownloadUrl] = useState("");
-  const [prompt, setPrompt] = useState("")
-
+  const [prompt, setPrompt] = useState("");
+  const user = auth.currentUser;
   useEffect(() => {
-
-    if(url === undefined || prompts === undefined){
-      return
+    if (url === undefined || prompts === undefined) {
+      return;
     }
 
-    const decodedUrl = decodeURIComponent(url)
-    const decodedPrompts = decodeURIComponent(prompts)
-
+    const decodedUrl = decodeURIComponent(url);
+    const decodedPrompts = decodeURIComponent(prompts);
 
     setImageUrl(decodedUrl);
-    setPrompt(decodedPrompts)
+    setPrompt(decodedPrompts);
   }, [url, prompts]);
 
-  // 로그인 인증에 따른 user 받아오는거 추가 예정
   useEffect(() => {
     const handleUpload = async () => {
-      const userId = "userID1234";
       try {
         if (imageUrl.trim() !== "") {
-          const url = await uploadImageToFirebase(imageUrl, userId);
-          setDownloadUrl(url);
+          const url = await uploadImageToFirebase(imageUrl);
+          if (typeof url === "string") {
+            setDownloadUrl(url);
+          } else {
+            throw new Error("Invalid URL format received");
+          }
         }
       } catch (error) {
         console.error("Error uploading image: ", error);
@@ -49,9 +50,7 @@ const Result = () => {
         </div>
       </div>
       <div className="flex flex-col items-center px-4 space-y-4 md:space-y-8 max-w-lg">
-        <h3 className="font-bold pt-8">
-          {prompt}입니다
-        </h3>
+        <h3 className="font-bold pt-8">{prompt}입니다</h3>
         <p className="text-gray">
           사진을 저장하고 기록하고 싶다면 로그인 해보세요
         </p>

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -18,5 +18,7 @@ const app = initializeApp(firebaseConfig);
 
 export const auth = getAuth(app);
 export const db = getFirestore(app);
-export const USERS_COLLECTION = collection(db, "users");
 export const storage = getStorage(app);
+export const USERS_COLLECTION = collection(db, "users");
+export const IMAGES_COLLECTION = (uid: string) =>
+  collection(db, `users/${uid}/images`);

--- a/src/services/uploadImage.ts
+++ b/src/services/uploadImage.ts
@@ -1,24 +1,40 @@
 import React from "react";
 import { ref, uploadBytes, getDownloadURL } from "firebase/storage";
-import { storage } from "../firebase";
+import { auth, storage, IMAGES_COLLECTION } from "../firebase";
+import { doc, setDoc } from "firebase/firestore";
 
-export const uploadImageToFirebase = async (
-  imageUrl: string,
-  userId: string,
-) => {
+export const uploadImageToFirebase = async (imageUrl: string) => {
   try {
-    imageUrl = imageUrl.replace('https://oaidalleapiprodscus.blob.core.windows.net', '');
+    imageUrl = imageUrl.replace(
+      "https://oaidalleapiprodscus.blob.core.windows.net",
+      "",
+    );
+    const user = auth.currentUser;
+    const uid = user?.uid;
+
     // 생성된 이미지 url을 사용해 이미지 다운로드
     const response = await fetch(imageUrl);
     const blob = await response.blob();
 
-    // 다운로드한 이미지를 Firebase Storage에 업로드
-    const storageRef = ref(storage, `images/${userId}.jpg`);
-    await uploadBytes(storageRef, blob);
+    const fileName = "randomName444";
+    const storageRef = ref(storage, `images/${fileName}.png`);
 
+    // 다운로드한 이미지를 Firebase Storage에 업로드
+    await uploadBytes(storageRef, blob).then((snapshot) => {
+      console.log("URL saved to storage!", snapshot);
+    });
     // 업로드된 이미지의 다운로드 url 가져오기
     const downloadUrl = await getDownloadURL(storageRef);
-    return downloadUrl;
+
+    // 로그인 상태인 경우, firestore의 uid로 users images 컬렉션에 url 저장
+    if (user !== null) {
+      if (!uid) throw new Error("User not authenticated");
+      const imagesCollectionRef = IMAGES_COLLECTION(uid);
+      const userDocRef = doc(imagesCollectionRef);
+      await setDoc(userDocRef, { url: downloadUrl, createdAt: new Date() });
+      console.log("URL successfully saved to firestore!");
+      return downloadUrl;
+    }
   } catch (error) {
     console.error("Error uploading image to Firebase:", error);
     throw error;


### PR DESCRIPTION
## 📝작업 내용

> 로그인을 하고 이미지를 만들었을 경우 uid를 확인하여 해당 유저의 firestore 컬렉션에 저장하는 것을 작업했습니다.
> uid를 확인하고 해당 유저의 firestore에 있는 이미지를 mypage에서 볼 수 있게 했습니다.

## 💬리뷰 요구사항(선택)

> openAI API가 제공하는 url이 지속성이 낮기 때문에, 비로그인이든 로그인이든 생성된 이미지를 storage에 넣은 이미지에 넣고 firebase에서 제공하는 downloadUrl을  firestore에 넣고 있습니다.