### PR TITLE
Update: 이미지 해상도 및 품질 다운그레이드

### DIFF
--- a/src/services/convertToWebP.ts
+++ b/src/services/convertToWebP.ts
@@ -12,24 +12,33 @@ export const convertToWebP = async (url: string): Promise<Blob | undefined> => {
 
       return new Promise((resolve, reject) => {
           img.onload = () => {
-              const canvas = document.createElement('canvas');
-              canvas.width = img.width;
-              canvas.height = img.height;
-              const ctx = canvas.getContext('2d');
+            const canvas = document.createElement('canvas');
+            
+            const ctx = canvas.getContext('2d');
 
               if (!ctx) {
                   throw new Error("이미지 생성 중 오류 발생")
               }
 
-              ctx.drawImage(img, 0, 0);
-              canvas.toBlob((webpBlob) => {
-                  if (!webpBlob) {
-                    reject(new Error("WebP Blob 생성 중 오류 발생"));
-                    return;
-                  }
-                  resolve(webpBlob);
-              }, 'image/webp');
-          };
+            canvas.width = 512
+            canvas.height = 512
+            const scale = Math.min(canvas.width / img.width, canvas.height / img.height);
+            const width = img.width * scale;
+            const height = img.height * scale;
+
+            const x = (canvas.width - width) / 2;
+            const y = (canvas.height - height) / 2;
+
+            ctx.drawImage(img, x, y, width, height);
+
+            canvas.toBlob((webpBlob) => {
+                if (!webpBlob) {
+                reject(new Error("WebP Blob 생성 중 오류 발생"));
+                return;
+                }
+                resolve(webpBlob);
+            }, 'image/webp', 0.5);
+        };
       });
   } catch (error) {
       console.error('Error converting to WebP:', error);


### PR DESCRIPTION
## #️⃣연관된 이슈

> #62 

## 📝작업 내용

> 이미지 해상도가 1024x1024로 사용되는 이미지보다 과도하게 해상도가 높은 것을 확인했습니다.
> canvas로 이미지를 그릴 때 절반인 512x512로 이미지로 해상도를 낮췄습니다.
> `toBlob`의 매개변수인 quality를 0.5로 설정해서 기본 화질의 50% 품질 저하를 일으켰습니다.

### 스크린샷 (선택)

<img width="362" alt="image" src="https://github.com/user-attachments/assets/04582b75-3de7-4bf3-92b2-880f39c92476">


## 💬결과

> 용량과 속도가 50%씩 절감 되었습니다.
> LightHouse Performance 부분도 50% => 56%로 증가했습니다.