### PR TITLE
Update: 코드 스플리팅: lazy, suspsnse / img 태그 Picture 컴포넌트로 확장

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,24 +1,13 @@
-import React, { useState, useEffect } from "react";
+import React, { lazy, Suspense } from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
-import { Home, SignUp, Survey, Result, MyPage } from "./pages";
+import { Home, SignUp, Survey, Result } from "./pages";
 import { AuthProvider } from "./contexts/AuthContext";
-import Generate from "./pages/Generate";
-//import { auth } from "./firebase";
+import Loading from "./components/Loading";
 
-function App() {
-  // 초기 인증 상태가 해결되는 즉시 해결되는 프로미스를 반환
-  // Firebase가 쿠키와 토큰을 읽고 백엔드와 소통하여 로그인 여부를 확인하는 동안 기다리는 Promise
-  // 프로미스가 해결되면 현재 사용자는 유효한 사용자이거나 사용자가 로그아웃한 경우 null일 수 있다.
-  // const init = async () => {
-  //   // 앱이 시작될 때 Firebase의 초기 인증 상태를 기다리고,
-  //   // 해당 상태가 resolve된 후에 앱을 렌더링하기 위해서 authStateReady() 사용함
-  //   await auth.authStateReady();
-  //   setIsLoading(false);
-  // };
-  // useEffect(() => {
-  //   init();
-  // }, []);
+const Generate = lazy(() => import("./pages/Generate"))
+const MyPage = lazy(() => import("./pages/MyPage"))
 
+const App = () => {
   return (
         <AuthProvider>
           <Router>
@@ -27,13 +16,18 @@ function App() {
               <Route path="/signup" element={<SignUp />} />
               <Route path="/home" element={<Home />} />
               <Route path="/survey" element={<Survey />} />
-              <Route path="/generate" element={<Generate/>}/>
-              <Route path="/result/:prompts/:url" element={<Result />} />
-              <Route path="/mypage" element={<MyPage />} />
+              <Route path="/generate" element={
+                <Suspense fallback={<Loading/>}>
+                  <Result />
+                </Suspense>}/>
+              <Route path="/result/:prompts/:url" element={<Result/>} />
+              <Route path="/mypage" element={ 
+                <Suspense fallback={<Loading/>}>
+                  <MyPage />
+                </Suspense>} />
             </Routes>
           </Router>
         </AuthProvider>
       )
     }
-
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,12 @@
 import React, { lazy, Suspense } from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
-import { Home, SignUp, Survey, Result } from "./pages";
+import { Home, Survey, Result } from "./pages";
 import { AuthProvider } from "./contexts/AuthContext";
 import Loading from "./components/Loading";
 
 const Generate = lazy(() => import("./pages/Generate"))
 const MyPage = lazy(() => import("./pages/MyPage"))
+const SignUp = lazy(() => import("./pages/SignUp"))
 
 const App = () => {
   return (
@@ -13,12 +14,15 @@ const App = () => {
           <Router>
             <Routes>
               <Route path="/" element={<Home />} />
-              <Route path="/signup" element={<SignUp />} />
+              <Route path="/signup" element={ 
+                <Suspense fallback={<Loading/>}>
+                  <SignUp />
+                </Suspense>} />
               <Route path="/home" element={<Home />} />
               <Route path="/survey" element={<Survey />} />
               <Route path="/generate" element={
                 <Suspense fallback={<Loading/>}>
-                  <Result />
+                  <Generate />
                 </Suspense>}/>
               <Route path="/result/:prompts/:url" element={<Result/>} />
               <Route path="/mypage" element={ 

--- a/src/Pages/Generate.tsx
+++ b/src/Pages/Generate.tsx
@@ -5,16 +5,6 @@ import { useEffect } from "react";
 import { imageGenerate } from "../services/imageGenerator";
 import { convertToWebP } from "../services/convertToWebP";
 import { uploadImageToFirebase } from "../services/uploadImageToFirebase";
-import styled from "styled-components";
-
-const Main = styled.main`
-    width: 100vw;
-    height: 100vh;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    background-color: #F8F6EE;
-`
 
 const Generate = () => {
     const location = useLocation()
@@ -51,11 +41,7 @@ const Generate = () => {
         processAndNavigate()
     }, [])
 
-    return (
-        <Main>
-            <Loading/>
-        </Main>
-    )
+    return <Loading/>
 }
 
 export default Generate

--- a/src/Pages/Result.tsx
+++ b/src/Pages/Result.tsx
@@ -3,6 +3,7 @@ import Button from "../components/Button";
 import { mainButtonArgs } from "../components/ButtonArgs";
 import { useParams } from "react-router-dom";
 import { useAuth } from "../contexts/AuthContext";
+import Picture from "../components/Picture";
 
 const Result = () => {
   const { prompts, url } = useParams();
@@ -41,32 +42,7 @@ const Result = () => {
       <div className="flex flex-col items-center px-4 space-y-4 max-w-lg">
         <h2 className="font-bold text-2xl">정호님의 이상형은</h2>
         <div>
-          <picture>
-            <source 
-              srcSet={`${imageUrl}.webp 320w,
-                      ${imageUrl}.webp 480w,
-                      ${imageUrl}.webp 800w,
-                      ${imageUrl}.webp 1024w`}
-              sizes="(max-width: 320px) 280px, 
-                    (max-width: 480px) 440px, 
-                    (max-width: 600px) 500px, 
-                    (max-width: 800px) 760px, 
-                    1024px"
-              type="image/webp"
-            />
-            <img 
-              src={`${imageUrl}.jpg`} 
-              alt="이상형 이미지" 
-              className="rounded-lg"
-              style={{  
-                width: "100%",
-                height: "auto",
-                maxWidth: "1024px", 
-                maxHeight: "1024px"
-              }}
-              loading="lazy"
-            />
-        </picture>
+          <Picture imageUrl={imageUrl} altText="이상형 이미지"/>
         </div>
       </div>
       <div className="flex flex-col items-center px-4 space-y-4 md:space-y-8 max-w-lg">

--- a/src/Pages/Survey.tsx
+++ b/src/Pages/Survey.tsx
@@ -5,7 +5,6 @@ import {
   genderTheme,
 } from "../components/Survey";
 import { useNavigate } from "react-router-dom";
-import Loading from "../components/Loading";
 
 type Gender = "남자" | "여자";
 

--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -1,14 +1,27 @@
 import React from "react";
+import styled from "styled-components";
+
+
+const Main = styled.main`
+    width: 100vw;
+    height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: #F8F6EE;
+`
 
 export const Loading = () => {
   const loading = process.env.PUBLIC_URL + "/images/spin.gif";
 
   return (
-    <div className="flex flex-col items-center">
-      <img src="/images/spin.gif" alt="loading" className="w-20 h-20" />
-      <p className="text-base font-bold mt-3">이상형을 찾고 있어요!</p>
-      <p className="text-sm mt-3">잠시만 기다려주세요.</p>
-    </div>
+    <Main>
+      <div className="flex flex-col items-center">
+        <img src="/images/spin.gif" alt="loading" className="w-20 h-20" />
+        <p className="text-base font-bold mt-3">이상형을 찾고 있어요!</p>
+        <p className="text-sm mt-3">잠시만 기다려주세요.</p>
+      </div>
+    </Main>
   );
 };
 

--- a/src/components/Picture.tsx
+++ b/src/components/Picture.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import styled from "styled-components";
+
+const Image = styled.img`
+  width: 100%;
+  height: auto;
+  max-width: 512px;
+  max-height: 512px;
+  border-radius: 12px;
+`
+
+interface PictureProps {
+    imageUrl: string,
+    altText: string
+}
+
+const Picture = ({imageUrl, altText}: PictureProps) => {
+    return (
+      <picture>
+        <source 
+          srcSet={`${imageUrl}.webp 320w,
+                  ${imageUrl}.webp 480w,
+                  ${imageUrl}.webp 800w,
+                  ${imageUrl}.webp 1024w`}
+          sizes="(max-width: 320px) 280px, 
+                (max-width: 480px) 440px, 
+                (max-width: 600px) 500px, 
+                (max-width: 800px) 760px, 
+                1024px"
+          type="image/webp"
+        />
+        <Image 
+          src={`${imageUrl}.jpg`} 
+          alt={altText} 
+          loading="lazy"
+        />
+      </picture>
+    );
+  };
+
+export default Picture


### PR DESCRIPTION
## #️⃣연관된 이슈

> #69 

## 📝작업 내용

> 리액트는 CSR로 최초 진입 시 모든 번들 파일을 다운받아 이후에 빠르게 동작합니다. 하지만, 최초에 모든 파일을 다운 받으려 하니 초기에 느릴 수 있습니다.
> 이를 해결하기 위해 lazy 함수로 번들 사이즈가 큰 페이지는 진입시에 번들 파일을 다운 받게끔 하여 최초 진입 시에는 진입하지 않은 페이지의 파일들을 다운받지 않습니다.
> 번들 파일들을 분석해보니 firebase 모듈러가 가장 큰 용량을 차지했기에 firebase를 사용하는 페이지는 모두 lazy처리 했습니다.


>img 태그에 picture 태그, source태그를 확장해서 붙이면 LightHouse점수가 오르는것을 보고 Picture 컴포넌트로 확장해 만들어 봤습니다 img는 이 컴포넌트를 쓰면 렌더링에 용이할 것 같습니다!

## 💬리뷰 요구사항

> 프로젝트가 소규모라 엄청 큰 체감은 없지만 performance가 5% 상승했습니다!