### PR TITLE
Update: 사진 저장 버튼 클릭시(새창열림->바로 다운로드), Feat: 결과 이미지 우클릭과 드래그 방지

### DIFF
--- a/src/Pages/Generate.tsx
+++ b/src/Pages/Generate.tsx
@@ -1,47 +1,52 @@
 import React from "react";
-import { useLocation, useNavigate } from "react-router-dom"
-import Loading from "../components/Loading"
+import { useLocation, useNavigate } from "react-router-dom";
+import Loading from "../components/Loading";
 import { useEffect } from "react";
 import { imageGenerate } from "../services/imageGenerator";
 import { convertToWebP } from "../services/convertToWebP";
 import { uploadImageToFirebase } from "../services/uploadImageToFirebase";
 
 const Generate = () => {
-    const location = useLocation()
-    const navigate = useNavigate()
+  const location = useLocation();
+  const navigate = useNavigate();
 
-    useEffect(() => {
-        const { prompts } = location.state;
-        const processAndNavigate = async () => {
-            try{
-                const data = await imageGenerate(prompts);
-                const responseUrl = data?.url
+  useEffect(() => {
+    const { prompts } = location.state;
+    const processAndNavigate = async () => {
+      try {
+        const data = await imageGenerate(prompts);
+        const responseUrl = data?.url;
 
-                if(!responseUrl){
-                    throw new Error("Failed to get response URL");
-                }
-                const webP = await convertToWebP(responseUrl)
-
-                if(!webP){
-                    throw new Error("Failed to convert to WebP");
-                }
-                const firebaseUrl = await uploadImageToFirebase(webP)
-
-                if(!firebaseUrl){
-                    throw new Error("Failed to upload and download Image to Firebase");
-                }
-
-
-                const newPrompts = prompts.join(" ")
-                navigate(`/result/${encodeURIComponent(newPrompts)}/${encodeURIComponent(firebaseUrl)}`)
-            }catch(error){
-                console.error(error)
-            }
+        if (!responseUrl) {
+          throw new Error("Failed to get response URL");
         }
-        processAndNavigate()
-    }, [])
+        const webP = await convertToWebP(responseUrl);
 
-    return <Loading/>
-}
+        if (!webP) {
+          throw new Error("Failed to convert to WebP");
+        }
+        const [firebaseUrl, firebaseFileName] =
+          await uploadImageToFirebase(webP);
 
-export default Generate
+        if (!firebaseUrl) {
+          throw new Error("Failed to upload and download Image to Firebase");
+        }
+
+        const newPrompts = prompts.join(" ");
+        navigate(
+          `/result/${encodeURIComponent(newPrompts)}/${encodeURIComponent(firebaseUrl)}`,
+          {
+            state: { fileName: firebaseFileName },
+          },
+        );
+      } catch (error) {
+        console.error(error);
+      }
+    };
+    processAndNavigate();
+  }, []);
+
+  return <Loading />;
+};
+
+export default Generate;

--- a/src/components/Picture.tsx
+++ b/src/components/Picture.tsx
@@ -7,35 +7,37 @@ const Image = styled.img`
   max-width: 512px;
   max-height: 512px;
   border-radius: 12px;
-`
+`;
 
 interface PictureProps {
-    imageUrl: string,
-    altText: string
+  imageUrl: string;
+  altText: string;
 }
 
-const Picture = ({imageUrl, altText}: PictureProps) => {
-    return (
-      <picture>
-        <source 
-          srcSet={`${imageUrl}.webp 320w,
+const Picture = ({ imageUrl, altText }: PictureProps) => {
+  return (
+    <picture>
+      <source
+        srcSet={`${imageUrl}.webp 320w,
                   ${imageUrl}.webp 480w,
                   ${imageUrl}.webp 800w,
                   ${imageUrl}.webp 1024w`}
-          sizes="(max-width: 320px) 280px, 
+        sizes="(max-width: 320px) 280px, 
                 (max-width: 480px) 440px, 
                 (max-width: 600px) 500px, 
                 (max-width: 800px) 760px, 
                 1024px"
-          type="image/webp"
-        />
-        <Image 
-          src={`${imageUrl}.jpg`} 
-          alt={altText} 
-          loading="lazy"
-        />
-      </picture>
-    );
-  };
+        type="image/webp"
+      />
+      <Image
+        src={`${imageUrl}.jpg`}
+        alt={altText}
+        loading="lazy"
+        onContextMenu={(e) => e.preventDefault()}
+        onDragStart={(e) => e.preventDefault()}
+      />
+    </picture>
+  );
+};
 
-export default Picture
+export default Picture;

--- a/src/services/uploadImageToFirebase.ts
+++ b/src/services/uploadImageToFirebase.ts
@@ -11,24 +11,27 @@ export const uploadImageToFirebase = async (webP: Blob) => {
 
     const fileName = uuid() + ".webP";
     const storageRef = ref(storage, `images/${fileName}`);
- 
+
     // 다운로드한 이미지를 Firebase Storage에 업로드
     const snapshot = await uploadBytes(storageRef, webP);
 
     // 업로드가 완료되면 다운로드 URL 가져오기
-    const downloadUrl = await getDownloadURL(snapshot.ref)
-
+    const downloadUrl = await getDownloadURL(snapshot.ref);
 
     // 로그인 상태인 경우, firestore의 uid로 users images 컬렉션에 url 저장
     if (user !== null) {
       if (!uid) throw new Error("User not authenticated");
       const imagesCollectionRef = IMAGES_COLLECTION(uid);
       const userDocRef = doc(imagesCollectionRef);
-      await setDoc(userDocRef, { url: downloadUrl, createdAt: new Date() });
+      await setDoc(userDocRef, {
+        fileName: fileName,
+        url: downloadUrl,
+        createdAt: new Date(),
+      });
       console.log("URL successfully saved to firestore!");
     }
 
-    return downloadUrl;
+    return [downloadUrl, fileName];
   } catch (error) {
     console.error("Error uploading image to Firebase:", error);
     throw error;


### PR DESCRIPTION
## 📝작업 내용

1. 사진 저장 아이콘을 클릭하면 이미지 파일이 바로 다운로드 되게 하기 위해 `a` 태그에 `download` 속성을 설정하였지만, 여전히 이미지가 새 창에서 열리는 문제가 있었습니다.
서버에서 `Content-Disposition: attachment` 헤더를 설정하여 해결할 수 있지만, 클라이언트 측만을 사용하는 경우엔 이를 설정 하기 어렵기 때문에 강제로 다운로드 트리거하는 방법을 사용했습니다. 
현재 사진 저장 아이콘을 클릭하면 이미지 파일이 바로 다운로드됩니다.

2. 사진저장 아이콘이 따로 있으므로, 결과 페이지에서 보여주는 이미지의 우클릭, 드래그 기능을 방지했습니다.

## 💬리뷰 요구사항(선택)

> 2번 관련해서는 Picture.tsx Image에만 추가했는데, 혹시 모든 페이지에서 동일한 기능이 필요하다고 판단된다면 App.tsx에 추가하면 좋을 것 같습니다.