### PR TITLE
Feat: 이미지 생성 횟수 제한, survey 페이지 이동 버튼 컴포넌트 추가

### DIFF
--- a/src/Pages/Generate.tsx
+++ b/src/Pages/Generate.tsx
@@ -1,14 +1,17 @@
-import React from "react";
+import React, { useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import Loading from "../components/Loading";
 import { useEffect } from "react";
 import { imageGenerate } from "../services/imageGenerator";
 import { convertToWebP } from "../services/convertToWebP";
 import { uploadImageToFirebase } from "../services/uploadImageToFirebase";
+import { useAuth } from "../contexts/AuthContext";
+import { getCountAndTimeLeft, incrementCount } from "../services/countService";
 
 const Generate = () => {
   const location = useLocation();
   const navigate = useNavigate();
+  const { currentUser } = useAuth();
 
   useEffect(() => {
     const { prompts, hashTags } = location.state;
@@ -39,6 +42,9 @@ const Generate = () => {
             state: { fileName: firebaseFileName },
           },
         );
+
+        const { count, limit } = await getCountAndTimeLeft(currentUser);
+        await incrementCount(currentUser, count, limit);
       } catch (error) {
         console.error(error);
       }

--- a/src/Pages/Home.tsx
+++ b/src/Pages/Home.tsx
@@ -12,6 +12,8 @@ import {
   googleButtonArgs,
 } from "../components/ButtonArgs";
 import { useAuth } from "../contexts/AuthContext";
+import NavigateToSurvey from "../components/NavigateToSurvey";
+import { getCountAndTimeLeft } from "../services/countService";
 
 const Home = () => {
   const navigate = useNavigate();
@@ -32,7 +34,13 @@ const Home = () => {
       console.log("User logged in: ", userCredential.user);
       setCurrentUser(userCredential.user);
       alert("로그인에 성공했습니다.");
-      navigate("/survey");
+
+      const { count, limit } = await getCountAndTimeLeft(currentUser);
+      if (count < limit) {
+        navigate("/survey");
+      } else {
+        navigate("/");
+      }
     } catch (error: any) {
       // 예외 처리
       switch (error.code) {
@@ -79,12 +87,7 @@ const Home = () => {
               />
             </>
           ) : (
-            <Button
-              label="로그인 없이 시작"
-              type="button"
-              {...mainButtonArgs}
-              onClick={() => navigate("/survey")}
-            />
+            <NavigateToSurvey label="로그인 없이 시작" />
           )}
         </section>
         {!currentUser && (

--- a/src/Pages/MyPage.tsx
+++ b/src/Pages/MyPage.tsx
@@ -11,6 +11,7 @@ import {
 } from "firebase/firestore";
 import { useAuth } from "../contexts/AuthContext";
 import { useNavigate } from "react-router-dom";
+import NavigateToSurvey from "../components/NavigateToSurvey";
 
 interface CardData {
   url: string;
@@ -48,12 +49,7 @@ const MyPage = () => {
   return (
     <main className="flex flex-col items-center space-y-8 bg-bg py-16">
       <h1 className="text-3xl font-bold">Josh님의 이상형 리스트 입니다.</h1>
-      <Button
-        label="새로운 이상형 찾기"
-        type="button"
-        {...mainButtonArgs}
-        onClick={() => navigate("/survey")}
-      />
+      <NavigateToSurvey label="새로운 이상형 찾기" />
       <section className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
         {cards.map((card, index) => (
           <div key={index} className="w-[250px]">

--- a/src/components/NavigateToSurvey.tsx
+++ b/src/components/NavigateToSurvey.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import { getCountAndTimeLeft } from "../services/countService";
+import { useAuth } from "../contexts/AuthContext";
+import Button from "./Button";
+import { mainButtonArgs } from "./ButtonArgs";
+
+interface NavigateToSurveyProps {
+  label: string;
+}
+
+const NavigateToSurvey = ({ label }: NavigateToSurveyProps) => {
+  const navigate = useNavigate();
+  const { currentUser } = useAuth();
+
+  const handleSurveyNavigation = async () => {
+    const { count, limit, timeLeft } = await getCountAndTimeLeft(currentUser);
+
+    if (count < limit) {
+      navigate("/survey");
+    } else if (!currentUser) {
+      alert(
+        "이미지 생성 횟수를 초과했습니다. 더 많은 횟수를 원하시면 로그인 해주세요.",
+      );
+    } else {
+      alert(
+        `이미지 생성 횟수를 초과했습니다. ${timeLeft.hours}시간 ${timeLeft.minutes}분 후에 이용해 주세요.`,
+      );
+    }
+  };
+
+  return (
+    <Button
+      label={label}
+      type="button"
+      {...mainButtonArgs}
+      onClick={handleSurveyNavigation}
+    />
+  );
+};
+
+export default NavigateToSurvey;

--- a/src/services/countService.ts
+++ b/src/services/countService.ts
@@ -1,0 +1,109 @@
+import { USERS_COLLECTION } from "../firebase";
+import { User } from "firebase/auth";
+import { doc, getDoc, updateDoc, setDoc } from "firebase/firestore";
+
+const USER_COUNT_LIMIT = 3;
+const ANONYMOUS_COUNT_LIMIT = 1;
+
+const formatTimeLeft = (
+  milliseconds: number,
+): { hours: number; minutes: number } => {
+  const totalMinutes = Math.floor(milliseconds / (1000 * 60));
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return { hours, minutes };
+};
+
+export const getCountAndTimeLeft = async (
+  user: User | null,
+): Promise<{ count: number; limit: number; timeLeft: any }> => {
+  const now = Date.now();
+  const cooldownPeriod = 24 * 60 * 60 * 1000;
+
+  if (user) {
+    // 로그인한 경우, firebase에 이미지 생성 횟수와 마지막 갱신 시간 저장
+
+    const userDocRef = doc(USERS_COLLECTION, user.uid);
+    const userDoc = await getDoc(userDocRef);
+    const data = userDoc.data();
+    const lastReset = data?.lastReset?.toDate();
+
+    // lastReset이 null일 경우 처리
+    const lastResetTime = lastReset ? lastReset.getTime() : 0;
+
+    // 현재 시간과 lastReset 시간의 경과 시간 계산
+    const timeElapsed = now - lastResetTime;
+
+    const userTimeLeft = Math.max(0, cooldownPeriod - timeElapsed);
+    const { hours, minutes } = formatTimeLeft(userTimeLeft);
+
+    if (!lastReset || (lastReset && now - lastResetTime > cooldownPeriod)) {
+      // 저장된 마지막 갱신 시간이 없는 경우이거나,
+      // 마지막 갱신 시간이 하루가 지난 경우, 생성 횟수 초기화 및 새로운 갱신 시간 저장
+      await updateDoc(userDocRef, {
+        count: 0,
+        lastReset: new Date(),
+      });
+      return {
+        count: 0,
+        limit: USER_COUNT_LIMIT,
+        timeLeft: { hours: 24, minutes: 0 },
+      };
+    } else {
+      // 마지막 갱신 시간이 하루가 지나지 않은 경우
+      return {
+        count: data?.count || 0,
+        limit: USER_COUNT_LIMIT,
+        timeLeft: { hours, minutes },
+      };
+    }
+  } else {
+    // 비로그인의 경우, localStorage에 이미지 생성 횟수와 마지막 갱신 시간 저장
+    const localCount = localStorage.getItem("imageGenCount");
+    const localLastReset = localStorage.getItem("imageGenLastReset");
+    const localLastResetTime = localLastReset
+      ? new Date(localLastReset).getTime()
+      : 0;
+
+    // 현재 시간과 localLastResetTime 시간의 경과 시간 계산
+    const timeElapsed = now - localLastResetTime;
+    const localTimeLeft = Math.max(0, cooldownPeriod - timeElapsed);
+    const { hours, minutes } = formatTimeLeft(localTimeLeft);
+
+    if (
+      !localLastReset ||
+      (localLastReset &&
+        new Date().getTime() - new Date(localLastResetTime).getTime() >
+          24 * 60 * 60 * 1000)
+    ) {
+      // 마지막 갱신 시간이 하루가 지난 경우
+      localStorage.setItem("imageGenCount", "0");
+      localStorage.setItem("imageGenLastReset", new Date().toISOString());
+      return {
+        count: 0,
+        limit: ANONYMOUS_COUNT_LIMIT,
+        timeLeft: { hours: 24, minutes: 0 },
+      };
+    } else {
+      // 마지막 갱신 시간이 하루가 지나지 않은 경우
+      return {
+        count: localCount ? parseInt(localCount, 10) : 0,
+        limit: ANONYMOUS_COUNT_LIMIT,
+        timeLeft: { hours, minutes },
+      };
+    }
+  }
+};
+
+export const incrementCount = async (
+  user: User | null,
+  currentCount: number,
+  limit: number,
+) => {
+  if (user) {
+    const userDocRef = doc(USERS_COLLECTION, user.uid);
+    await updateDoc(userDocRef, { count: currentCount + 1 });
+  } else {
+    localStorage.setItem("imageGenCount", (currentCount + 1).toString());
+  }
+};


### PR DESCRIPTION
## 📝작업 내용

> 이미지를 생성할 수 있는 횟수를 제한하는 작업을 했습니다. 로그인한 경우에는 firebase에 count와 갱신 날짜를 저장해서 사용했고, 비로그인인 경우에는 localStorage로 사용했습니다.
> survey 버튼 클릭 시 count, limit 확인 후 navigate하기 위해 컴포넌트를 추가했습니다.

## 💬리뷰 요구사항(선택)

- 현재 로그인 시 제한 횟수 3회, 비로그인시 제한 횟수 1회로 해놓았습니다. 횟수는 의논해보고 수정해도 될 것 같습니다.
- 이미지 생성 횟수 초과하고 갱신 시간이 지나지 않았는데 재로그인한 경우에 survey로 바로 이동 안되게는 해놨으나, 웹 주소창에 `/survey`로 입력해서 접근한 경우에는 가능한 상태입니다. 이 부분은 수정이 필요해 보입니다.