### PR TITLE
Fix: Result 페이지 로그인여부 판별 로직 수정

### DIFF
--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -15,13 +15,7 @@ const Result = () => {
   const location = useLocation();
   const { fileName } = location.state || {};
   const navigate = useNavigate();
-  const [loading, setLoading] = useState<boolean>(true);
-
-  useEffect(() => {
-    if (!currentUser) {
-      setLoading(false);
-    }
-  }, [currentUser]);
+  const isLogin = currentUser.currentUser;
 
   useEffect(() => {
     if (prompts === undefined || url === undefined) {
@@ -80,7 +74,7 @@ const Result = () => {
       <div className="flex flex-col items-center px-4 space-y-4 md:space-y-8 max-w-lg">
         <h3 className="font-bold pt-8">{prompt}</h3>
 
-        {!loading && currentUser ? (
+        {isLogin ? (
           <>
             <Button
               label={"마이페이지"}
@@ -104,7 +98,7 @@ const Result = () => {
           </>
         )}
         <div>
-          {!loading && currentUser && (
+          {isLogin && (
             <button onClick={handleDownload} className="size-8 mr-6">
               <img src="/images/icon-photo.png" alt="사진저장 아이콘" />
             </button>


### PR DESCRIPTION
## 📝작업 내용

Result 페이지에서 로그인 여부를 제대로 판별하지 못하는 버그를 수정했습니다. 
기존에 상태 판별 값으로 사용하던 currentUser은 객체로 반환되기 때문에 currentUser.currentUser로 접근해야 null값으로 가져올 수 있습니다.


