### PR TITLE
Feat: 마이페이지에 결과페이지 url 추가, Update: 바로 다운로드 기능 모바일에도 가능하게 수정

### DIFF
--- a/src/components/Picture.tsx
+++ b/src/components/Picture.tsx
@@ -29,13 +29,7 @@ const Picture = ({ imageUrl, altText }: PictureProps) => {
                 1024px"
         type="image/webp"
       />
-      <Image
-        src={`${imageUrl}.jpg`}
-        alt={altText}
-        loading="lazy"
-        onContextMenu={(e) => e.preventDefault()}
-        onDragStart={(e) => e.preventDefault()}
-      />
+      <Image src={`${imageUrl}.jpg`} alt={altText} loading="lazy" />
     </picture>
   );
 };

--- a/src/components/PreventDefaultWrapper.tsx
+++ b/src/components/PreventDefaultWrapper.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+interface PreventDefaultWrapperProps {
+  children: React.ReactNode;
+}
+
+export const PreventDefaultWrapper = ({
+  children,
+}: PreventDefaultWrapperProps) => {
+  const handlePreventDefault = (event: React.SyntheticEvent) => {
+    event.preventDefault();
+  };
+
+  return (
+    <div
+      onContextMenu={handlePreventDefault}
+      onDragStart={handlePreventDefault}
+      onTouchStart={handlePreventDefault}
+    >
+      {children}
+    </div>
+  );
+};

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -16,6 +16,7 @@ interface CardData {
   createdAt: Date;
   fileName: string;
   hashTags?: string[] | null;
+  resultUrl?: string | null;
 }
 
 const MyPage = () => {
@@ -37,6 +38,7 @@ const MyPage = () => {
               createdAt: data.createdAt.toDate(),
               fileName: data.fileName,
               hashTags: data.hashTags,
+              resultUrl: data.resultUrl,
             };
             newCards.push(cardData);
           });
@@ -62,7 +64,11 @@ const MyPage = () => {
       <NavigateToSurvey label="새로운 이상형 찾기" />
       <section className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
         {cards.map((card, index) => (
-          <div key={index} className="w-[250px]">
+          <div
+            key={index}
+            className="w-[250px]"
+            onClick={() => navigate(`${card.resultUrl}`)}
+          >
             <div className="p-4">
               <img
                 src={card.url}

--- a/src/services/saveResultUrlToFirebase.ts
+++ b/src/services/saveResultUrlToFirebase.ts
@@ -1,0 +1,32 @@
+import { User } from "firebase/auth";
+import { db, IMAGES_COLLECTION } from "../firebase";
+import { doc, updateDoc } from "firebase/firestore";
+
+interface SaveResultUrlParams {
+  user: User | null;
+  imageDocId: string | null;
+  resultUrl: string | null;
+}
+
+export const saveResultUrlToFirebase = async ({
+  user,
+  imageDocId,
+  resultUrl,
+}: SaveResultUrlParams) => {
+  try {
+    if (!user)
+      throw new Error("User not authenticated. Cannot update result URL.");
+    if (!imageDocId) throw new Error("Image document ID is required.");
+
+    const imagesCollectionRef = IMAGES_COLLECTION(user.uid);
+    const imageDocRef = doc(imagesCollectionRef, imageDocId);
+
+    await updateDoc(imageDocRef, {
+      resultUrl: resultUrl,
+    });
+
+    console.log("Result URL successfully updated in Firestore!");
+  } catch (error) {
+    console.error("Error updating result URL in Firestore:", error);
+  }
+};


### PR DESCRIPTION
## 📝작업 내용

1. user인 경우 firestore images 컬렉션에 결과 페이지 url을 저장하는 코드를 추가했습니다. 마이페이지에서 해당 생성 사진의 결과 페이지로 이동 가능하게끔 했습니다.
2. 바로 다운로드 기능 모바일에도 가능하게 수정했습니다.
3. 생성된 이미지에만 적용했던 기본 기능 방지가 아이콘에도 드래그, 우클릭, 터치 기능을 방지하는 것이 필요하다고 판단됐고, 관련 코드를 컴포넌트로 만들어서 사용했습니다.

## 💬리뷰 요구사항(선택)

1. 마이페이지에서 각 카드 전체를 영역으로 잡아서 클릭 이벤트를 넣었는데 사진에만 적용하면 좋을지 의논해보면 좋을 것 같습니다.
2. 제 핸드폰으로 테스트해보니 모바일에서는 바로 다운로드가 안되고 있었습니다. iOS 기기에서는 a 태그를 통해 파일을 다운로드하는 방식이 제한적일 수 있다고 합니다. 그래서 canvas를 사용해 수정해놓았습니다. 
그런데 이 방법이 모바일이 최신 버전인 경우에만 적용 가능한 방법일 수 있어서 배포 환경에서 테스트 진행 후에 수정 여부를 봐야할 것 같습니다. 수정이 필요하다면 아마도 라이브러리(file-saver)를 사용해야할 것 같습니다.