### PR TITLE
refactor: AI 요청 프롬프트 수정

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -38,6 +38,10 @@ const Button = styled.button<
   &:hover {
     background-color: ${(props) => props.$hoverColor};
   }
+    
+  &:active {
+  background-color: ${(props) => props.$backgroundColor || "#007BFF"};
+  }
 `;
 
 function StyledButton({ label, type = "button", ...props }: ButtonProps) {

--- a/src/components/Survey.ts
+++ b/src/components/Survey.ts
@@ -26,19 +26,19 @@ export const surveyContentsWomen: Survey[] = [
   {
     question: "원하는 연령대를 골라주세요",
     options: [
-      { label: "10대", value: "teenager" },
-      { label: "20대", value: "twenties" },
-      { label: "30대", value: "thirties" },
-      { label: "40대", value: "forties" },
-      { label: "50대 이상", value: "fifties and older" },
+      { label: "10대", value: "10s" },
+      { label: "20대", value: "20s" },
+      { label: "30대", value: "30s" },
+      { label: "40대", value: "40s" },
+      { label: "50대 이상", value: "50s and over" },
     ],
   },
   {
     question: "원하는 체형을 골라주세요",
     options: [
-      { label: "마른 체형", value: "slim body" },
-      { label: "통통한 체형", value: "chubby body" },
-      { label: "근육질 체형", value: "muscular body" },
+      { label: "마른 체형", value: "slim" },
+      { label: "통통한 체형", value: "chubby" },
+      { label: "근육질 체형", value: "muscular" },
     ],
   },
   {
@@ -55,14 +55,14 @@ export const surveyContentsWomen: Survey[] = [
   {
     question: "원하는 피부색을 골라주세요",
     options: [
-      { label: "엑스트라 화이트 톤", value: "extra white skin tone" },
-      { label: "밝고 환한 밀크 톤", value: "bright milk skin tone" },
-      { label: "차분한 아이보리 톤", value: "calm ivory skin tone" },
+      { label: "엑스트라 화이트 톤", value: "white skin" },
+      { label: "밝고 환한 밀크 톤", value: "bright milk skin" },
+      { label: "차분한 아이보리 톤", value: "calm ivory skin" },
       {
         label: "자연스러운 미디엄 다크 톤",
-        value: "natural medium dark skin tone",
+        value: "natural medium dark skin",
       },
-      { label: "태닝한 듯 건강한 다크 톤", value: "tanned dark skin tone" },
+      { label: "태닝한 듯 건강한 다크 톤", value: "tanned dark skin" },
     ],
   },
   {
@@ -76,11 +76,11 @@ export const surveyContentsWomen: Survey[] = [
   {
     question: "원하는 머리 스타일을 골라주세요",
     options: [
-      { label: "시크한 여자 숏컷", value: "short haircut" },
-      { label: "귀여운 단발", value: "bob haircut" },
-      { label: "자연스러운 중단발", value: "medium length hair" },
-      { label: "청순한 긴생머리", value: "long straight hair" },
-      { label: "여신 웨이브", value: "long curly hair" },
+      { label: "시크한 여자 숏컷", value: "short" },
+      { label: "귀여운 단발", value: "bob" },
+      { label: "자연스러운 중단발", value: "medium length" },
+      { label: "청순한 긴생머리", value: "long straight" },
+      { label: "여신 웨이브", value: "long curly" },
     ],
   },
   {
@@ -96,11 +96,11 @@ export const surveyContentsWomen: Survey[] = [
   {
     question: "옷 스타일을 골라주세요",
     options: [
-      { label: "심플한 캐주얼룩", value: "wearing a simple casual look" },
-      { label: "깔끔한 정장", value: "wearing a suit" },
-      { label: "힙한 mz룩", value: "wearing a hip hop look" },
-      { label: "편한 트레이닝복", value: "wearing a sports wear" },
-      { label: "페스티벌룩", value: "wearing a festival look" },
+      { label: "심플한 캐주얼룩", value: "simple casual style" },
+      { label: "깔끔한 정장", value: "suit" },
+      { label: "힙한 mz룩", value: "hip hop style" },
+      { label: "편한 트레이닝복", value: "sports style" },
+      { label: "페스티벌룩", value: "festival style" },
     ],
   },
 ];
@@ -109,19 +109,19 @@ export const surveyContentsMen: Survey[] = [
   {
     question: "원하는 연령대를 골라주세요",
     options: [
-      { label: "10대", value: "teenager" },
-      { label: "20대", value: "twenties" },
-      { label: "30대", value: "thirties" },
-      { label: "40대", value: "forties" },
-      { label: "50대 이상", value: "fifties and older" },
+      { label: "10대", value: "10s" },
+      { label: "20대", value: "20s" },
+      { label: "30대", value: "30s" },
+      { label: "40대", value: "40s" },
+      { label: "50대 이상", value: "50s and over" },
     ],
   },
   {
     question: "원하는 체형을 골라주세요",
     options: [
-      { label: "마른 체형", value: "slim body" },
-      { label: "통통한 체형", value: "chubby body" },
-      { label: "근육질 체형", value: "muscular body" },
+      { label: "마른 체형", value: "slim" },
+      { label: "통통한 체형", value: "chubby" },
+      { label: "근육질 체형", value: "muscular" },
     ],
   },
   {
@@ -138,14 +138,14 @@ export const surveyContentsMen: Survey[] = [
   {
     question: "원하는 피부색을 골라주세요",
     options: [
-      { label: "엑스트라 화이트 톤", value: "extra white skin tone" },
-      { label: "밝고 환한 밀크 톤", value: "bright milk skin tone" },
-      { label: "차분한 아이보리 톤", value: "calm ivory skin tone" },
+      { label: "엑스트라 화이트 톤", value: "extra white skin" },
+      { label: "밝고 환한 밀크 톤", value: "bright milk skin" },
+      { label: "차분한 아이보리 톤", value: "calm ivory skin" },
       {
         label: "자연스러운 미디엄 다크 톤",
-        value: "natural medium dark skin tone",
+        value: "natural medium dark skin",
       },
-      { label: "태닝한 듯 건강한 다크 톤", value: "tanned dark skin tone" },
+      { label: "태닝한 듯 건강한 다크 톤", value: "tanned dark skin" },
     ],
   },
   {
@@ -159,11 +159,11 @@ export const surveyContentsMen: Survey[] = [
   {
     question: "원하는 머리 스타일을 골라주세요",
     options: [
-      { label: "깔끔한 짧은 머리", value: "short hair" },
-      { label: "덮은머리", value: "slicked back hair" },
-      { label: "한껏 꾸민 포마드", value: "pompadour hairstyle" },
-      { label: "뽀글이 펌", value: "poppy perm hair" },
-      { label: "느낌 있는 장발", value: "long hair" },
+      { label: "깔끔한 짧은 머리", value: "short" },
+      { label: "덮은머리", value: "with front bangs" },
+      { label: "한껏 꾸민 포마드", value: "pompadour" },
+      { label: "뽀글이 펌", value: "poppy perm" },
+      { label: "느낌 있는 장발", value: "long" },
     ],
   },
   {
@@ -179,11 +179,11 @@ export const surveyContentsMen: Survey[] = [
   {
     question: "원하는 옷 스타일을 골라주세요",
     options: [
-      { label: "심플한 캐주얼룩", value: "wearing a simple casual look" },
-      { label: "깔끔한 정장", value: "wearing a suit" },
-      { label: "힙한 mz룩", value: "wearing a hip hop look" },
-      { label: "편한 트레이닝복", value: "wearing a sports wear" },
-      { label: "페스티벌룩", value: "wearing a festival look" },
+      { label: "심플한 캐주얼룩", value: "simple casual style" },
+      { label: "깔끔한 정장", value: "suit" },
+      { label: "힙한 mz룩", value: "hip hop style" },
+      { label: "편한 트레이닝복", value: "sports style" },
+      { label: "페스티벌룩", value: "festival style" },
     ],
   },
 ];

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from "react";
-import Loading from "../components/Loading";
 import { IMAGES_COLLECTION } from "../firebase";
 import {
   query,

--- a/src/services/imageGenerator.ts
+++ b/src/services/imageGenerator.ts
@@ -1,26 +1,35 @@
-import OpenAI from 'openai';
+import OpenAI from "openai";
 
 export const maxDuration = 300;
-export const dynamic = 'force-dynamic';
+export const dynamic = "force-dynamic";
 
 const openai = new OpenAI({
   apiKey: process.env.REACT_APP_OPEN_AI_API_KEY,
-  dangerouslyAllowBrowser: true
+  dangerouslyAllowBrowser: true,
 });
- 
+
 export async function imageGenerate(order: string[]) {
-  const prompt = "A person who is " + order.join(' ') + " realistic full-body photo" 
+  const fixPrompt = [
+    "passport-style",
+    "realistic",
+    "professional",
+    "plain light-colored background",
+    "soft lighting",
+    "natural",
+    "polished",
+    "refined",
+  ];
+  const prompt = "korean, " + order.join(", ") + fixPrompt.join(", ");
 
   try {
     const response = await openai.images.generate({
-      model: 'dall-e-3',
+      model: "dall-e-3",
       prompt: prompt,
       n: 1,
-      size: '1024x1024',
+      size: "1024x1024",
     });
 
-    return response?.data[0]
-
+    return response?.data[0];
   } catch (err) {
     console.error(err);
   }


### PR DESCRIPTION
## #️⃣연관된 이슈

> 설문 결과가 실사처럼 안나오는 이슈가

## 📝작업 내용

- `korean`으로 명시하여 구체적인 프롬프트를 전달했습니다
- 세부적인 키워드들을 조금 조정했습니다
- gpt4를 통해 dall-e 모델이 실사로 만들 수 있는 프롬프트 키워드들을 학습하여 적용했습니다 `(fixPrompt)`
- 특히 `passport-style`이라는 키워드에는 유독 실사처럼 보여주어 더욱 높은 퀄리티를 제공합니다
- 키워드를 공백으로 나눠 요청하면 dall-e가 따로 의역해서 이미지를 생성했는데 `,`로 구분하니 키워드 대로 그려줍니다.

## 리뷰어들에게
- 유독 전신샷 혹은 상반샷은 다수의 사람을 보여주던가 그림티가 너무 나는 이미지만 보여주어 적용을 못했습니다.
- 가끔 대한민국 국기를 그린다던지, 카메라 앵글을 그린다던지 하는 오류가 있지만, 인물들은 대체로 완성도 높게 보여주는 것을 확인했습니다!
==============================================
- 실수로 PR을 한꺼번에 해버려서 취소하고 다시 PR올립니다!

## 스크린샷
![image](https://github.com/user-attachments/assets/3bc92d85-6a17-4d31-9f83-22a92a32299c)
