### PR TITLE
fix: 응답 prompts JSON으로 변경

### DIFF
--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -31,7 +31,7 @@ const Result = () => {
   const isLogin = currentUser.currentUser;
 
   useEffect(() => {
-    const result = parseProfile(profile);
+    const result = JSON.parse(profile);
     setImageProfile(result);
   }, [profile]);
 
@@ -99,8 +99,8 @@ const Result = () => {
     <Main>
       <FlexBox direction="column" gap="47px">
         <FlexBox direction="column" gap="2px">
-          <Text fontWeight="bold">26세 나현아</Text>
-          <Text fontSize="lg" fontWeight="bold">패션 인플루언서</Text>
+          <Text fontWeight="bold">{imageProfile?.age} {imageProfile?.name}</Text>
+          <Text fontSize="lg" fontWeight="bold">{imageProfile?.occupation}</Text>
         </FlexBox>
           <PreventDefaultWrapper>
             <Picture imageUrl={imageUrl} altText="이상형 이미지" />
@@ -108,6 +108,8 @@ const Result = () => {
       </FlexBox>
       <FlexBox direction="column">
         <Text fontWeight="bold">{prompt}</Text>
+        <Text fontWeight="bold">성격: {imageProfile?.personality}</Text>
+        <Text fontWeight="bold">취미: {imageProfile?.hobbies}</Text>
 
         {isLogin ? (
           <>

--- a/src/services/profileGenerator.ts
+++ b/src/services/profileGenerator.ts
@@ -8,7 +8,7 @@ const openai = new OpenAI({
 export async function profileGenerate(order: string[]) {
   const prompt = `Create a realistic and coherent profile with the following characteristics: ${order.join(
     ", ",
-  )}. Generate a name, age, occupation, personality traits, and hobbies for this profile. Please provide the response in Korean.`;
+  )}. Generate a name, age, occupation, personality traits, and hobbies for this profile. Please provide the response in a valid JSON format with keys "name", "age", "occupation", "personality  ", and "hobbies". The response should be in Korean.`;
 
   try {
     const response = await openai.chat.completions.create({
@@ -37,6 +37,7 @@ interface Profile {
   personality: string;
   hobbies: string;
 }
+
 // 문자열을 객체로 변환하는 함수
 export const parseProfile = (responseText: string): Profile => {
   const profile = {


### PR DESCRIPTION
## 📝작업 내용

> 요청한 prompts를 json string형식으로 응답받고 JSON.parse()로 JSON형태로 가공하여 다시 사용하게끔 수정했습니다.

### 스크린샷 (선택)
#### firestore에 저장되었는지 확인
![image](https://github.com/user-attachments/assets/55ab8f6e-114b-4d1e-93d9-aa213f82e8ba)
#### console.log로 해당 JSON.parse가 되었는지 확인
![image](https://github.com/user-attachments/assets/bfc73232-2ad4-41c4-93b3-d9841831a5af)
#### 결과물 (성격 키 값을 잘못 설정해 수정 필요)
![image](https://github.com/user-attachments/assets/cb414349-149a-40e2-b703-361d08eb5de7)

## 💬리뷰 요구사항(선택)

> location으로 profile들을 받고 있어 공유시에는 데이터를 제대로 읽어오지 못하는데 firebase를 개편하면서 한번 수정해보도록 하겠습니다.

> 현재는 유저 컬렉션만 운용중이고 유저 컬렉션에 게시물 정보들을 저장하는 형식인데 이를 개편해보겠습니다.
![image](https://github.com/user-attachments/assets/f53c2e2f-3d43-4eb7-98b6-a9173a6fe1d7)

> 전체 게시물 컬렉션을 추가해서 해당 게시물의 정보 (이미지, profile 등)을 넣어주고 게시물에 id값을 부여해 id값을 추적하고 유지보수 하도록 계획중입니다.

> 추후에 진행해보고 올려드리겠습니다!