### PR TITLE
Refactor: generate, result 페이지에서 뒤로가기 방지 기능 추가

### DIFF
--- a/src/pages/Generate.tsx
+++ b/src/pages/Generate.tsx
@@ -17,6 +17,15 @@ const Generate = () => {
 
   useEffect(() => {
     const { prompts, hashTags } = location.state;
+
+    // 뒤로가기 방지
+    const blockBackButton = () => {
+      window.history.pushState(null, "", window.location.href);
+    };
+
+    window.history.pushState(null, "", window.location.href);
+    window.addEventListener("popstate", blockBackButton);
+
     const processAndNavigate = async () => {
       try {
         // 이미지 생성
@@ -60,6 +69,7 @@ const Generate = () => {
         }
 
         navigate(resultUrl, {
+          replace: true, // 현재 페이지를 대체
           state: { fileName: firebaseFileName, profile: profile },
         });
 
@@ -70,6 +80,11 @@ const Generate = () => {
       }
     };
     processAndNavigate();
+
+    // 언마운트 시 뒤로가기 이벤트리스너 제거
+    return () => {
+      window.removeEventListener("popstate", blockBackButton);
+    };
   }, []);
 
   return <Loading />;

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -47,6 +47,20 @@ const Result = () => {
     setPrompt(decodedPrompts);
   }, [url, prompts]);
 
+  // 뒤로가기 방지
+  useEffect(() => {
+    const blockBackButton = () => {
+      window.history.pushState(null, "", window.location.href);
+    };
+
+    window.history.pushState(null, "", window.location.href);
+    window.addEventListener("popstate", blockBackButton);
+
+    return () => {
+      window.removeEventListener("popstate", blockBackButton);
+    };
+  }, []);
+
   const handleDownload = async () => {
     try {
       const response = await fetch(imageUrl);
@@ -99,12 +113,16 @@ const Result = () => {
     <Main>
       <FlexBox direction="column" gap="47px">
         <FlexBox direction="column" gap="2px">
-          <Text fontWeight="bold">{imageProfile?.age} {imageProfile?.name}</Text>
-          <Text fontSize="lg" fontWeight="bold">{imageProfile?.occupation}</Text>
+          <Text fontWeight="bold">
+            {imageProfile?.age} {imageProfile?.name}
+          </Text>
+          <Text fontSize="lg" fontWeight="bold">
+            {imageProfile?.occupation}
+          </Text>
         </FlexBox>
-          <PreventDefaultWrapper>
-            <Picture imageUrl={imageUrl} altText="이상형 이미지" />
-          </PreventDefaultWrapper>
+        <PreventDefaultWrapper>
+          <Picture imageUrl={imageUrl} altText="이상형 이미지" />
+        </PreventDefaultWrapper>
       </FlexBox>
       <FlexBox direction="column">
         <Text fontWeight="bold">{prompt}</Text>
@@ -113,7 +131,9 @@ const Result = () => {
 
         {isLogin ? (
           <>
-            <Button onClick={() => handleNavigate("/mypage")}>마이 페이지</Button>
+            <Button onClick={() => handleNavigate("/mypage")}>
+              마이 페이지
+            </Button>
             <NavigateToSurvey label="이상형 다시 찾기" />
           </>
         ) : (


### PR DESCRIPTION
## 📝작업 내용

generate 페이지와 result 페이지에서 뒤로가기를 방지하는 기능을 추가하였습니다.

`window.history.pushState()` : 브라우저 히스토리 스택에 새로운 URL을 표시하여 새로운 페이지도 이동한 것처럼 보이는 API입니다. 그러나 실제 페이지는 리로드되지 않고 URL만 변경됩니다.

## 💬리뷰 요구사항(선택)

마이페이지 -> 결과페이지 뒤로가기도 방지하는 것이 좋을까요? 
어차피 마이페이지에서 결과페이지로 이동이 가능해서 따로 설정하지 않았는데 필요하다고 생각되시면 말씀해주세요!