### PR TITLE
refactor: firebase DB 구조 변경에 따른 로직 변경

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,7 +33,7 @@ const App = () => {
               </Suspense>
             }
           />
-          <Route path="/result/:prompts/:url" element={<Result />} />
+          <Route path="/result/:postId" element={<Result />} />
           <Route
             path="/mypage"
             element={

--- a/src/services/profileGenerator.ts
+++ b/src/services/profileGenerator.ts
@@ -29,38 +29,3 @@ export async function profileGenerate(order: string[]) {
     console.error(error);
   }
 }
-
-interface Profile {
-  name: string;
-  age: number;
-  occupation: string;
-  personality: string;
-  hobbies: string;
-}
-
-// 문자열을 객체로 변환하는 함수
-export const parseProfile = (responseText: string): Profile => {
-  const profile = {
-    name: "",
-    age: 0,
-    occupation: "",
-    personality: "",
-    hobbies: "",
-  };
-
-  // 각 항목을 추출하기 위한 정규식
-  const nameMatch = responseText.match(/이름:\s*(.*)/i);
-  const ageMatch = responseText.match(/나이:\s*(\d+)/i);
-  const occupationMatch = responseText.match(/직업:\s*(.*)/i);
-  const personalityMatch = responseText.match(/성격(?: 특징)?:\s*(.*)/i);
-  const hobbiesMatch = responseText.match(/취미:\s*(.*)/i);
-
-  // 정규식 결과를 프로필 객체에 할당
-  if (nameMatch) profile.name = nameMatch[1].trim();
-  if (ageMatch) profile.age = parseInt(ageMatch[1], 10);
-  if (occupationMatch) profile.occupation = occupationMatch[1].trim();
-  if (personalityMatch) profile.personality = personalityMatch[1].trim();
-  if (hobbiesMatch) profile.hobbies = hobbiesMatch[1].trim();
-
-  return profile;
-};

--- a/src/services/uploadImageToFirebase.ts
+++ b/src/services/uploadImageToFirebase.ts
@@ -1,13 +1,10 @@
 import React from "react";
 import { ref, uploadBytes, getDownloadURL } from "firebase/storage";
-import { auth, storage, IMAGES_COLLECTION } from "../firebase";
-import { doc, setDoc } from "firebase/firestore";
+import { storage } from "../firebase";
 import { v4 as uuid } from "uuid";
 
-export const uploadImageToFirebase = async (webP: Blob, hashTags: string[], profile: string) => {
+export const uploadImageToFirebase = async (webP: Blob) => {
   try {
-    const user = auth.currentUser;
-
     const fileName = uuid() + ".webP";
     const storageRef = ref(storage, `images/${fileName}`);
 
@@ -18,26 +15,8 @@ export const uploadImageToFirebase = async (webP: Blob, hashTags: string[], prof
     const downloadUrl = await getDownloadURL(snapshot.ref);
 
     // 로그인 상태인 경우, firestore의 uid로 users images 컬렉션에 url, profile 저장
-    if (user) {
-      const uid = user?.uid;
-      const imagesCollectionRef = IMAGES_COLLECTION(uid);
-      const userDocRef = doc(imagesCollectionRef);
 
-      await setDoc(userDocRef, {
-        fileName: fileName,
-        url: downloadUrl,
-        createdAt: new Date(),
-        hashTags: hashTags,
-        profile: profile,
-      });
-
-      console.log("URL successfully saved to firestore!");
-      return [downloadUrl, fileName, userDocRef.id];
-    } else {
-      // 로그인하지 않은 경우, url을 Firestore에는 저장하지 않음
-      console.log("User not authenticated. URL saved only to Storage.");
-      return [downloadUrl, fileName, null];
-    }
+    return downloadUrl;
   } catch (error) {
     console.error("Error uploading image to Firebase:", error);
     throw error;


### PR DESCRIPTION
## 📝작업 내용

> 전에 설명드린것과 같이 Firebase에 DB 구조를 변경하면서 로직을 변경했습니다.

### 스크린샷

#### Posts
![image](https://github.com/user-attachments/assets/f07942df-4a53-4d04-bb3e-69afc82ebb2b)
- posts에는 숫자로 각 post에 id가 부여됩니다.
- 각 post에 필요한 정보가 담깁니다.


#### Users
![image](https://github.com/user-attachments/assets/276d6dc0-0448-4cd1-820a-dd4ebdcaa418)
- users에는 각 user의 uid로 문서가 생성되고 작성한 post의 id는 postList 필드에 저장됩니다.
- 마이페이지를 렌더링 할 때 이 user의 post정보들을 토대로 렌더링 됩니다.

## 💬리뷰 요구사항

> DB 구조 변화에 따른 users 컬렉션의 images 컬렉션을 삭제를 고려중인데 필요하신 데이터가 있으시면 말씀해주세요!