### PR TITLE
Feat: 회원가입 이메일 인증 로직 추가, Refactor: 유효성 검사 및 firebase 회원가입 로직 분리

### DIFF
--- a/src/components/functional/EmailVerificationModal.tsx
+++ b/src/components/functional/EmailVerificationModal.tsx
@@ -1,0 +1,113 @@
+import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { sendEmailVerification } from "firebase/auth";
+import { useAuth } from "../../contexts/AuthContext";
+import styled from "styled-components";
+import { Button } from "../ui/Button";
+
+interface EmailVerificationModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const EmailVerificationModal = ({
+  isOpen,
+  onClose,
+}: EmailVerificationModalProps) => {
+  const navigate = useNavigate();
+  const { currentUser } = useAuth();
+  const [isSending, setIsSending] = useState(false);
+  const [isVerified, setIsVerified] = useState(false);
+
+  const sendVerificationEmail = () => {
+    if (!currentUser) return;
+    setIsSending(true);
+
+    sendEmailVerification(currentUser)
+      .then(() => {
+        alert("이메일 인증 메일이 발송되었습니다.");
+      })
+      .catch((error) => {
+        console.error("이메일 전송 오류:", error);
+        alert("인증 메일 전송에 실패했습니다. 다시 시도해주세요.");
+      })
+      .finally(() => {
+        setIsSending(false);
+      });
+  };
+
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      if (currentUser) {
+        currentUser.reload().then(() => {
+          if (currentUser.emailVerified) {
+            setIsVerified(true);
+            clearInterval(intervalId);
+            onClose(); // 이메일 인증이 완료되면 모달 닫기
+            alert("이메일 인증이 완료되었습니다. 로그인하세요.");
+            navigate("/");
+          }
+        });
+      }
+    }, 5000);
+    return () => clearInterval(intervalId);
+  }, [onClose]);
+
+  // 모달이 열려 있는 상태일 때만 렌더링
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <ModalBackdrop>
+      <ModalContent>
+        <h2 style={{ fontWeight: "bold", fontSize: "20px" }}>
+          이메일 인증 요청
+        </h2>
+        <p>회원가입을 완료하려면 이메일 인증을 완료해주세요.</p>
+        <div style={{ marginTop: "24px" }}>
+          <Button onClick={sendVerificationEmail} disabled={isSending}>
+            {isSending ? "메일 전송 중..." : "인증 메일 전송"}
+          </Button>
+          <Button
+            style={{ marginLeft: "20px" }}
+            bgColor="sub"
+            onClick={onClose}
+          >
+            닫기
+          </Button>
+        </div>
+      </ModalContent>
+    </ModalBackdrop>
+  );
+};
+
+export default EmailVerificationModal;
+
+const ModalBackdrop = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const ModalContent = styled.div`
+  display: flex;
+  flex-flow: column;
+  align-items: center;
+  justify-content: center;
+  row-gap: 24px;
+  position: absolute;
+  width: 100vw;
+  height: 100vh;
+  background-color: white;
+  padding: 2rem;
+  background-color: rgb(255, 255, 255);
+  border-radius: 10px;
+  text-align: center;
+`;

--- a/src/components/functional/EmailVerificationModal.tsx
+++ b/src/components/functional/EmailVerificationModal.tsx
@@ -25,7 +25,7 @@ const EmailVerificationModal = ({
 
     sendEmailVerification(currentUser)
       .then(() => {
-        alert("이메일 인증 메일이 발송되었습니다.");
+        alert("이메일 인증 메일이 발송되었습니다. 이메일을 확인해주세요.");
       })
       .catch((error) => {
         console.error("이메일 전송 오류:", error);

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -2,46 +2,46 @@ import React from "react";
 import styled from "styled-components";
 import { ColorMap } from "../utils/ColorMap";
 
-export interface ButtonProps{
-    label?: string;
-    width?: string;
-    height?: string;
-    bgColor?: "main" | "sub" | "white" ;
-    children?: React.ReactNode;
-    style?: React.CSSProperties; 
-    onClick?: () => void
-  }
+export interface ButtonProps {
+  label?: string;
+  width?: string;
+  height?: string;
+  bgColor?: "main" | "sub" | "white" | "disabled";
+  children?: React.ReactNode;
+  style?: React.CSSProperties;
+  onClick?: (e: React.FormEvent) => void;
+  disabled?: boolean;
+}
 
 const ButtonStyle = styled.button<ButtonProps>`
-  background-color: ${({bgColor}) => bgColor ? ColorMap[bgColor].background : ColorMap['main'].background};
+  background-color: ${({ bgColor }) =>
+    bgColor ? ColorMap[bgColor].background : ColorMap["main"].background};
   color: white;
   font-size: 1rem;
-  width: ${({width}) => width || 'auto'};
-  height: ${({height}) => height || 'auto'};
-  padding: ${({ children }) => typeof children === 'string' ? '0.8rem 0' : '0'};
+  width: ${({ width }) => width || "auto"};
+  height: ${({ height }) => height || "auto"};
+  padding: ${({ children }) =>
+    typeof children === "string" ? "0.8rem 0" : "0"};
   border-radius: 0.375rem;
   border: none;
   transition: background-color 0.2s ease-in-out;
   cursor: pointer;
   &:hover {
-    background-color: ${({bgColor}) => bgColor ? ColorMap[bgColor].hover : ColorMap['main'].hover};
+    background-color: ${({ bgColor }) =>
+      bgColor ? ColorMap[bgColor].hover : ColorMap["main"].hover};
   }
-    
+
   &:active {
-    background-color: ${({bgColor}) => bgColor ? ColorMap[bgColor].background : ColorMap['main'].background};
+    background-color: ${({ bgColor }) =>
+      bgColor ? ColorMap[bgColor].background : ColorMap["main"].background};
   }
 `;
 
-export const Button = ({children, label, style, ...props }: ButtonProps) => {
-  const ariaLabel = typeof children === 'string' ? children : label;
+export const Button = ({ children, label, style, ...props }: ButtonProps) => {
+  const ariaLabel = typeof children === "string" ? children : label;
   return (
-    <ButtonStyle 
-      aria-label={ariaLabel}
-      role="button"
-      style={style}
-      {...props}
-    >
+    <ButtonStyle aria-label={ariaLabel} role="button" style={style} {...props}>
       {children}
     </ButtonStyle>
   );
-}
+};

--- a/src/components/ui/Text.ts
+++ b/src/components/ui/Text.ts
@@ -12,8 +12,12 @@ export const Text = styled.p<{
   fontSize?: "xs" | "sm" | "md" | "lg" | "xl";
   fontWeight?: string;
   color?: string;
+  marginRight?: string;
+  marginLeft?: string;
 }>`
   color: ${({ color = "inherit" }) => color};
   font-size: ${({ fontSize = "md" }) => fontSizes[fontSize]};
   font-weight: ${({ fontWeight = "normal" }) => fontWeight};
+  margin-right: ${({ marginRight }) => marginRight};
+  margin-left: ${({ marginLeft }) => marginLeft};
 `;

--- a/src/components/utils/ColorMap.ts
+++ b/src/components/utils/ColorMap.ts
@@ -1,5 +1,5 @@
 export const ColorMap: {
-  [key: string]: { background: string; hover: string };
+  [key: string]: { background: string; hover?: string };
 } = {
   main: {
     background: "#706EF4",
@@ -20,5 +20,8 @@ export const ColorMap: {
   white: {
     background: "white",
     hover: "#f0f0f0",
+  },
+  disabled: {
+    background: "#b1b5c1",
   },
 };

--- a/src/components/utils/Validation.ts
+++ b/src/components/utils/Validation.ts
@@ -1,0 +1,19 @@
+export const validateEmail = (value: string): string => {
+  const emailRegEx =
+    /^[A-Za-z0-9]([-_.]?[A-Za-z0-9])*@[A-Za-z0-9]([-_.]?[A-Za-z0-9])*\.[A-Za-z]{2,3}$/;
+  return emailRegEx.test(value) ? "" : "이메일 형식을 확인해주세요.";
+};
+
+export const validatePassword = (value: string): string => {
+  const passwordRegEx = /^[A-Za-z0-9]{6,}$/;
+  return passwordRegEx.test(value)
+    ? ""
+    : "비밀번호는 영문, 숫자를 혼합하여 6자 이상 입력해주세요.";
+};
+
+export const validateConfirmPassword = (
+  password: string,
+  confirmPassword: string,
+): string => {
+  return password === confirmPassword ? "" : "비밀번호가 일치하지 않습니다.";
+};

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -1,78 +1,87 @@
 import Input from "../components/ui/Input";
-import React, { useState } from "react";
-import { useNavigate } from "react-router-dom";
-import { createUserWithEmailAndPassword, AuthError } from "firebase/auth";
-import { auth, db, USERS_COLLECTION } from "../firebase";
-import { doc, setDoc, query, where, getDocs } from "firebase/firestore";
+import React, { useCallback, useState } from "react";
+import { AuthError } from "firebase/auth";
 import { Button } from "../components/ui/Button";
 import { Main } from "../components/ui/Main";
 import { FlexBox } from "../components/ui/FlexBox";
 import { Text } from "../components/ui/Text";
 import { Header } from "../components/ui/Header";
+import {
+  validateConfirmPassword,
+  validateEmail,
+  validatePassword,
+} from "../components/utils/Validation";
+import {
+  saveUserInfo,
+  signUpWithEmail,
+} from "../services/auth/signupWithEmail";
+import EmailVerificationModal from "../components/functional/EmailVerificationModal";
 
 const SignUp = () => {
-  const navigate = useNavigate();
+  const [isModalOpen, setModalOpen] = useState(true);
+
   const [email, setEmail] = useState<string>("");
   const [password, setPassword] = useState<string>("");
   const [confirmPassword, setConfirmPassword] = useState<string>("");
+
+  // 유효성 검사 결과 상태
   const [error, setError] = useState<string>("");
+  const [emailError, setEmailError] = useState<string>("");
+  const [passwordError, setPasswordError] = useState<string>("");
+  const [confirmPasswordError, setConfirmPasswordError] = useState<string>("");
 
-  // 이메일 중복 검사
-  const checkEmail = async () => {
-    const q = query(USERS_COLLECTION, where("email", "==", email));
-    const querySnapshot = await getDocs(q);
+  // 이메일 변경 시 유효성 검사 적용
+  const handleEmailChange = useCallback(
+    (value: string) => {
+      setError("");
+      setEmail(value);
+      setEmailError(validateEmail(value));
+    },
+    [email],
+  );
 
-    if (!querySnapshot.empty) return setError("이미 사용 중인 이메일입니다.");
-  };
+  // 비밀번호 변경 시 유효성 검사 적용
+  const handlePasswordChange = useCallback(
+    (value: string) => {
+      setError("");
+      setPassword(value);
+      setPasswordError(validatePassword(value));
+    },
+    [password],
+  );
 
-  // 유저 정보 저장
-  const saveUserInfo = async (uid: string) => {
-    await setDoc(doc(db, "users", uid), {
-      uid: uid,
-      email: email,
-      password: password,
-    });
-  };
+  // 비밀번호 재확인 변경 시 유효성 검사 적용
+  const handleConfirmPasswordChange = useCallback(
+    (value: string) => {
+      setError("");
+      setConfirmPassword(value);
+      setConfirmPasswordError(validateConfirmPassword(password, value));
+    },
+    [confirmPassword],
+  );
 
-  const handleSignUp = async () => {
-    if (password !== confirmPassword) {
-      setError("비밀번호가 일치하지 않습니다.");
-      return;
-    }
+  const handleSignUp = async (event: React.FormEvent) => {
+    event.preventDefault();
 
     try {
-      checkEmail();
-
       // 회원가입 처리
-      const userCredential = await createUserWithEmailAndPassword(
-        auth,
-        email,
-        password,
-      );
-      const user = userCredential.user;
+      const user = await signUpWithEmail(email, password);
+      await saveUserInfo(user.uid, email);
 
-      saveUserInfo(user.uid);
-
-      alert("회원가입이 완료됐습니다.");
-      navigate("/");
+      alert("회원가입이 완료됐습니다. 이메일 인증 후 이용해주세요.");
+      setModalOpen(true);
     } catch (err) {
       const error = err as AuthError;
       // firebase 오류 처리
       switch (error.code) {
-        case "auth/user-not-found" || "auth/wrong-password":
-          return setError("이메일 혹은 비밀번호가 일치하지 않습니다.");
-        // case "auth/email-already-in-use":
-        //   return setError("이미 사용 중인 이메일입니다.");
-        case "auth/weak-password":
-          return setError("비밀번호는 6글자 이상이어야 합니다.");
+        case "auth/email-already-in-use":
+          return setEmailError("이미 사용 중인 이메일입니다.");
         case "auth/network-request-failed":
           return setError("네트워크 연결에 실패 하였습니다.");
-        case "auth/invalid-email":
-          return setError("잘못된 이메일 형식입니다.");
         case "auth/internal-error":
           return setError("잘못된 요청입니다.");
         default:
-          return "회원가입에 실패 하였습니다.";
+          return alert("회원가입에 실패 하였습니다. 다시 시도해주세요.");
       }
     }
   };
@@ -82,36 +91,108 @@ const SignUp = () => {
       <Header></Header>
       <Main>
         <FlexBox direction="column" gap="32px">
-          <FlexBox direction="column" gap="10px" style={{alignItems: "flex-start", width: "100%"}}>
-            <Text fontSize="lg" fontWeight="bold">회원가입</Text>
+          <FlexBox
+            direction="column"
+            gap="10px"
+            style={{ alignItems: "flex-start", width: "100%" }}
+          >
+            <Text fontSize="lg" fontWeight="bold">
+              회원가입
+            </Text>
             <Text fontSize="md">이상형을 찾기 위한 여정 시작</Text>
           </FlexBox>
-            <FlexBox direction="column" gap="12px">
-              <Input
-                type="email"
-                placeholder="이메일을 입력해주세요"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                />
-              <Input
-                type="password"
-                placeholder="비밀번호를 입력해주세요"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                />
-              <Input
-                type="password"
-                placeholder="비밀번호를 한번 더 입력해주세요"
-                value={confirmPassword}
-                onChange={(e) => setConfirmPassword(e.target.value)}
-                />
-              {error ? <Text color="red">{error}</Text> : null}
-            </FlexBox>
-            <div style={{paddingTop: "32px", width: "100%"}}>
-              <Button label="회원가입하기" bgColor="main" onClick={handleSignUp}>회원가입하기</Button>
-            </div>
+          <FlexBox direction="column" gap="12px">
+            <Input
+              type="email"
+              placeholder="이메일을 입력해주세요"
+              value={email}
+              onChange={(e) => handleEmailChange(e.target.value)}
+            />
+            {emailError && (
+              <Text
+                color="red"
+                fontSize="sm"
+                marginRight="auto"
+                marginLeft="0.5rem"
+              >
+                {emailError}
+              </Text>
+            )}
+            <Input
+              type="password"
+              placeholder="비밀번호를 입력해주세요"
+              value={password}
+              onChange={(e) => handlePasswordChange(e.target.value)}
+            />
+            {passwordError && (
+              <Text
+                color="red"
+                fontSize="sm"
+                marginRight="auto"
+                marginLeft="0.5rem"
+              >
+                {passwordError}
+              </Text>
+            )}
+            <Input
+              type="password"
+              placeholder="비밀번호를 한번 더 입력해주세요"
+              value={confirmPassword}
+              onChange={(e) => handleConfirmPasswordChange(e.target.value)}
+            />
+            {confirmPasswordError && (
+              <Text
+                color="red"
+                fontSize="sm"
+                marginRight="auto"
+                marginLeft="0.5rem"
+              >
+                {confirmPasswordError}
+              </Text>
+            )}
+            {error ? (
+              <Text
+                color="red"
+                fontSize="sm"
+                marginRight="auto"
+                marginLeft="0.5rem"
+              >
+                {error}
+              </Text>
+            ) : null}
+          </FlexBox>
+          <div style={{ paddingTop: "32px", width: "100%" }}>
+            {!email ||
+            !password ||
+            !confirmPassword ||
+            emailError ||
+            passwordError ||
+            confirmPasswordError ? (
+              <Button
+                width="100%"
+                label="회원가입하기"
+                bgColor="disabled"
+                disabled={true}
+              >
+                회원가입하기
+              </Button>
+            ) : (
+              <Button
+                width="100%"
+                label="회원가입하기"
+                bgColor="main"
+                onClick={(e) => handleSignUp(e)}
+              >
+                회원가입하기
+              </Button>
+            )}
+          </div>
         </FlexBox>
       </Main>
+      <EmailVerificationModal
+        isOpen={isModalOpen}
+        onClose={() => setModalOpen(false)}
+      />
     </>
   );
 };

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -18,7 +18,7 @@ import {
 import EmailVerificationModal from "../components/functional/EmailVerificationModal";
 
 const SignUp = () => {
-  const [isModalOpen, setModalOpen] = useState(true);
+  const [isModalOpen, setModalOpen] = useState(false);
 
   const [email, setEmail] = useState<string>("");
   const [password, setPassword] = useState<string>("");

--- a/src/services/auth/signupWithEmail.ts
+++ b/src/services/auth/signupWithEmail.ts
@@ -1,0 +1,17 @@
+import { auth, db } from "../../firebase";
+import { createUserWithEmailAndPassword } from "firebase/auth";
+import { doc, setDoc } from "firebase/firestore";
+
+export const signUpWithEmail = async (email: string, password: string) => {
+  const userCredential = await createUserWithEmailAndPassword(
+    auth,
+    email,
+    password,
+  );
+  const user = userCredential.user;
+  return user;
+};
+
+export const saveUserInfo = async (uid: string, email: string) => {
+  await setDoc(doc(db, "users", uid), { uid, email });
+};


### PR DESCRIPTION
## 📝작업 내용

1. 유효성 검사 추가했고, 유효성 검사 로직과 firebase 관련 회원가입 로직을 분리했습니다.
2. 버튼 활성화 구현에서 hover가 없는 회색컬러가 필요해서 ColorMap > "disabled" 추가했습니다.
3. 회원가입 후 이메일 인증 로직 추가했습니다.

3-1. 처음에 진행하려고 했던 흐름은 이메일 인증 후 회원가입을 완료하는 것이었습니다.
3-2. 그러나, firebase에서 제공하는 인증 방식에서는 원하는 로직을 구현하기 어려웠습니다. firebase에서 제공하는 메서들 중 저희 프로젝트에 적용해볼 수 있다고 판단되는 메서드들입니다.
- `createUserWithEmailAndPassword` : 인증 절차 없이 이메일과 비밀번호로 바로 회원가입 가능한 방식입니다. 기존에 이 방식만 적용하여 구현한 상태였습니다. 
- `sendSignInLinkToEmail` : 회원가입용이라기 보단, 이메일 링크를 통해서 비밀번호 없이 로그인하는 방식입니다. 
- `sendEmailVerification` : 회원가입을 완료한 이메일이 유효한 이메일인지 인증하는 메서드입니다. 해당 메서드를 사용하기 위해서는 회원가입을 먼저 완료해야 합니다.

3-3. 사용자 몰래 이메일만 임시로 저장하고 그 이메일을 인증하는 방식으로 구현할 수는 있으나, 사용자에게 투명하지 않고 보안상 문제가 될 수 있을 것이라고 생각했습니다.
3-4. 사용자의 경험을 최대한 고려해서 선택한 방식은 회원 가입 후 이메일 인증을 모달로 처리하는 것입니다.
- 회원가입 절차는 빨리 끝내고 인증 후 서비스를 이용할 수 있게 했습니다.
- 사용자가 비밀번호를 직접 설정하고 인증 과정을 투명하게 할 수 있습니다.
- 인증 여부를 계속 확인해 인증을 유도하여 직관적인 흐름을 제공할 수 있습니다.
- 모바일 웹 사용자도 고려하여 모달은 페이지 전체 영역의 크기로 잡았습니다.

### 스크린샷 (선택)
![유효성검사](https://github.com/user-attachments/assets/15ae277a-a458-47dc-9f08-b5c3e3437254)
![가입완료 후 인증필요 알림](https://github.com/user-attachments/assets/70e1e199-fef4-4ab9-90bb-c3ce7973aa23)
![이메일 발송 버튼 클릭 후 발송 알림](https://github.com/user-attachments/assets/413a710a-8228-4211-b092-65dee06f334b)
![인증모달 및 완료 알림](https://github.com/user-attachments/assets/ef694deb-c52e-4768-a24e-1882045fb119)


## 💬리뷰 요구사항(선택)
1. 참고한 블로그 링크와 firebase 이메일 인증 방식에 대한 내용이 나온 링크 공유드립니다.
>https://choisuhyeok.tistory.com/144
>https://firebase.google.com/docs/auth/web/email-link-auth?hl=ko&_gl=1*gfqbkf*_up*MQ..*_ga*NDMwMTcxMTE3LjE3MjcxNDc3MTg.*_ga_CW55HF8NVT*MTcyNzE0NzcxOC4xLjAuMTcyNzE0NzcxOC4wLjAuMA..
2. 혹시 로직 관련해서 다른 의견 있으시면 공유 부탁드립니다.