### PR TITLE
Fix: 홈페이지에 '로그인 없이 시작' 버튼 다시 추가

### DIFF
--- a/src/components/functional/NavigateToSurvey.tsx
+++ b/src/components/functional/NavigateToSurvey.tsx
@@ -18,7 +18,9 @@ const NavigateToSurvey = ({ label }: NavigateToSurveyProps) => {
     if (count < limit) {
       navigate("/genderselect");
     } else if (!currentUser) {
-      const confirmed = confirm("기본 이미지 생성 횟수를 초과했습니다. 로그인을 위해 로그인 페이지로 이동합니다.")
+      const confirmed = confirm(
+        "기본 이미지 생성 횟수를 초과했습니다. 로그인을 위해 로그인 페이지로 이동합니다.",
+      );
       if (confirmed) {
         navigate("/");
       }
@@ -30,10 +32,12 @@ const NavigateToSurvey = ({ label }: NavigateToSurveyProps) => {
   };
 
   return (
-    <div style={{padding: "1rem 0", width: "70%"}}>
-      <Button width="100%" onClick={handleSurveyNavigation}>{label}</Button>
+    <div style={{ padding: "1rem 0", width: "100%" }}>
+      <Button width="100%" onClick={handleSurveyNavigation}>
+        {label}
+      </Button>
     </div>
-)
+  );
 };
 
 export default NavigateToSurvey;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -12,6 +12,7 @@ import { Text } from "../components/ui/Text";
 import { FirebaseError } from "firebase/app";
 import { useResponsive } from "../hooks/useResponsive";
 import FindPasswordModal from "../components/functional/FindPasswordModal";
+import NavigateToSurvey from "../components/functional/NavigateToSurvey";
 
 const Home = () => {
   const navigate = useNavigate();
@@ -95,6 +96,7 @@ const Home = () => {
         >
           로그인하기
         </Button>
+        <NavigateToSurvey label="로그인 없이 시작" />
       </FlexBox>
       <FlexBox direction="column" gap="8rem">
         <div>

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -62,7 +62,6 @@ const SignUp = () => {
 
   const handleSignUp = async (event: React.FormEvent) => {
     event.preventDefault();
-
     try {
       // 회원가입 처리
       const user = await signUpWithEmail(email, password);


### PR DESCRIPTION
## 📝작업 내용

> 홈페이지에 원래 있었던 로그인 없이 시작 버튼을 다시 넣었습니다.

## 💬리뷰 요구사항(선택)

> '로그인 없이 시작' 버튼의 디자인을 '로그인하기' 버튼과 동일하게 만들어놨어서 일단 '로그인하기' 버튼 밑에 배치해뒀습니다. 근데 조금 이상하게 보여서 금요일에 디자인 및 위치 재조정에 대해 논의할 필요가 있을 것 같습니다!