### PR TITLE
feat: 무한 스크롤 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@emotion/styled": "^11.13.0",
         "@mui/material": "^5.16.6",
         "@tanstack/react-query": "^5.59.0",
+        "@tanstack/react-query-devtools": "^5.59.0",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -5335,6 +5336,15 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.58.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.58.0.tgz",
+      "integrity": "sha512-iFdQEFXaYYxqgrv63ots+65FGI+tNp5ZS5PdMU1DWisxk3fez5HG3FyVlbUva+RdYS5hSLbxZ9aw3yEs97GNTw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tanstack/react-query": {
       "version": "5.59.0",
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.59.0.tgz",
@@ -5348,6 +5358,22 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.59.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.59.0.tgz",
+      "integrity": "sha512-Kz7577FQGU8qmJxROIT/aOwmkTcxfBqgTP6r1AIvuJxVMVHPkp8eQxWQ7BnfBsy/KTJHiV9vMtRVo1+R1tB3vg==",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.58.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.59.0",
         "react": "^18 || ^19"
       }
     },

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@emotion/styled": "^11.13.0",
     "@mui/material": "^5.16.6",
     "@tanstack/react-query": "^5.59.0",
+    "@tanstack/react-query-devtools": "^5.59.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { doc, getDoc } from "firebase/firestore";
 import { useAuth } from "../contexts/AuthContext";
 import { useNavigate } from "react-router-dom";
@@ -10,114 +10,153 @@ import { Card } from "../styles/styled";
 import { Main } from "../components/ui/Main";
 import { db } from "../firebase";
 import { Header } from "../components/ui/Header";
-import { Dropdown } from "../components/ui/Dropdown";
-
-interface CardData {
-  imageUrl: string;
-  id: string;
-  createdAt: Date;
-  fileName: string;
-  hashTags?: string[] | null;
-  resultUrl?: string | null;
-  profile?: string | null;
-}
+import { useInfiniteQuery } from "@tanstack/react-query";
 
 const MyPage = () => {
-  const [cards, setCards] = useState<CardData[]>([]);
-  const [initialCards, setInitialCards] = useState<CardData[]>([]);
-  const [dropdownSpan, setDropdownSpan] = useState<string>('최신 순')
   const { currentUser } = useAuth();
+  const [isImageLoaded, setIsImageLoaded] = useState(false)
   const navigate = useNavigate();
+  const observer = useRef<IntersectionObserver | null>(null);
+
+  const getCardsData = async (pageParam: number) => {
+    try {
+      if (currentUser) {
+        const uid = currentUser.uid;
+        const docRef = doc(db, "users", uid);
+        const usersSnapShot = await getDoc(docRef);
+        const userData = usersSnapShot.data();
+
+        if (!userData) return { cards: [], nextPage: undefined };
+
+        const postList = userData.postList.slice(pageParam * 4, pageParam * 4 + 4);
+
+        const fetchedCards = await Promise.all(
+          postList.map(async (num: string) => {
+            const postRef = doc(db, "posts", num);
+            const postSnapShot = await getDoc(postRef);
+            const data = postSnapShot.data();
+
+            if (!data) return null;
+
+            return {
+              imageUrl: data.imageUrl,
+              createdAt: data.createdAt.toDate(),
+              fileName: data.fileName,
+              hashTags: data.hashTags,
+              resultUrl: `${window.location.href}/result/${data.id}`,
+              profile: data.profile,
+              id: data.id,
+            };
+          }),
+        );
+
+        const validCards = fetchedCards.filter(card => card !== null);
+
+        return {
+          cards: validCards,
+          nextPage: validCards.length === 4 ? pageParam + 1 : undefined,
+        }
+      } else {
+        alert("로그인이 필요한 서비스입니다. 홈으로 이동합니다.");
+        navigate("/");
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const { data, isLoading, hasNextPage, fetchNextPage } =
+		useInfiniteQuery({
+			queryKey: ["posts"],
+			queryFn: ({ pageParam }) => getCardsData(pageParam as number),
+			initialPageParam: 0,
+			getNextPageParam: (lastPage) => {
+        return lastPage?.nextPage ?? null;
+			},
+		});
+
+  // 카드 데이터 처리
+  const cards = data?.pages.flatMap(page => page?.cards) || [];
 
   useEffect(() => {
-    const getCardsData = async () => {
-      try {
-        if (currentUser) {
-          const uid = currentUser.uid;
-
-          const docRef = doc(db, "users", uid);
-          const usersSnapShot = await getDoc(docRef);
-          const userData = usersSnapShot.data();
-
-          if (!userData) return;
-
-          const postList = userData.postList;
-
-          const fetchCardsData = async () => {
-            try {
-              const fetchedCards = await Promise.all(
-                postList.map(async (num: string) => {
-                  const postRef = doc(db, "posts", num);
-                  const postSnapShot = await getDoc(postRef);
-                  const data = postSnapShot.data();
-
-                  if (!data) return null; // 데이터를 가져오지 못한 경우 null 반환
-
-                  return {
-                    imageUrl: data.imageUrl,
-                    createdAt: data.createdAt.toDate(), // Timestamp를 Date 객체로 변환
-                    fileName: data.fileName,
-                    hashTags: data.hashTags,
-                    resultUrl: `${window.location.href}/result/${data.id}`,
-                    profile: data.profile,
-                    id: data.id,
-                  };
-                }),
-              );
-
-              // null 값이 있을 수 있으므로 필터링
-              setCards(fetchedCards);
-              setInitialCards(fetchedCards)
-            } catch (error) {
-              console.error("Error fetching cards data:", error);
-            }
-          };
-          fetchCardsData();
-        } else {
-          alert("로그인이 필요한 서비스입니다. 홈으로 이동합니다.");
-          navigate("/");
-        }
-      } catch (error) {
-        console.error(error);
+    const loadMore = (entries: IntersectionObserverEntry[]) => {
+      if (entries[0].isIntersecting && hasNextPage) {
+        fetchNextPage();
       }
     };
-    getCardsData();
-  }, [currentUser]);
 
-  useEffect(() => {
-    if(dropdownSpan === "최신 순"){
-      setCards(initialCards)
-    }else{
-      setCards((prevCards) => [...prevCards].reverse())
+    if (observer.current) {
+      observer.current.disconnect();
     }
-  },[dropdownSpan])
+
+    observer.current = new IntersectionObserver(loadMore, {
+      root: null, // 뷰포트를 기준으로 함
+      rootMargin: "0px",
+      threshold: 1.0, // 100% 가시성이 있어야 트리거
+    });
+
+    const target = document.getElementById("infinityQueryTrigger"); // 추가할 엘리먼트의 ID
+    if (target) {
+      observer.current.observe(target);
+    }
+
+    return () => {
+      if (observer.current) {
+        observer.current.disconnect();
+      }
+    };
+  }, [hasNextPage, fetchNextPage]);
+
+  if (isLoading) {
+    return <div>로딩 중...</div>;
+  }
 
   return (
     <>
-      <Header></Header>
+      <Header />
       <Main>
         <FlexBox direction="column">
           <Text fontSize="xl" fontWeight="bold" style={{ padding: "1rem 0" }}>
             {currentUser?.email}님의 이상형 리스트 입니다.
           </Text>
-          <Dropdown dropdownSpan={dropdownSpan} setDropdownSpan={setDropdownSpan}/>
           <NavigateToSurvey label="새로운 이상형 찾기" />
           <GridBox>
             {cards.map((card, index) => (
               <Card key={index} onClick={() => navigate(`/result/${card.id}`)}>
                 <FlexBox direction="column" gap="16px">
-                  <img
-                    src={card.imageUrl}
-                    alt={card.fileName}
-                    style={{
-                      width: "100%",
-                      height: "auto",
-                      borderRadius: "0.375rem 0.375rem 0 0",
-                    }}
-                  />
+                  {/* 이미지가 로드될 때까지 회색 박스를 유지 */}
+                  <div style={{ position: 'relative', width: '100%', height: '200px' }}>
+                    {!isImageLoaded && (
+                      <div
+                        style={{
+                          width: '100%',
+                          height: '100%',
+                          backgroundColor: '#e0e0e0',
+                          borderRadius: "0.375rem 0.375rem 0 0",
+                          position: 'absolute',
+                          top: 0,
+                          left: 0,
+                        }}
+                      />
+                    )}
+                    <img
+                      src={card.imageUrl}
+                      alt={card.fileName}
+                      style={{
+                        width: "100%",
+                        height: "auto",
+                        borderRadius: "0.375rem 0.375rem 0 0",
+                        display: isImageLoaded ? "block" : "none", // 이미지가 로드될 때만 표시
+                        position: 'absolute', // 회색 박스와 겹치도록
+                        top: 0,
+                        left: 0,
+                      }}
+                      onLoad={() => setIsImageLoaded(true)} // 이미지가 로드되면 상태 갱신
+                    />
+                  </div>
                   <FlexBox direction="column" gap="16px">
                     <FlexBox direction="column">
-                      {card.hashTags?.map((hashTag, index) => (
+                      {card.hashTags?.map((hashTag: string, index:number) => (
                         <span
                           key={index}
                           style={{
@@ -139,6 +178,7 @@ const MyPage = () => {
               </Card>
             ))}
           </GridBox>
+          {hasNextPage && <div id="infinityQueryTrigger" style={{ height: '20px' }}></div>}
         </FlexBox>
       </Main>
     </>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #129 

## 📝작업 내용

> `useInfinityQuery`로 무한 스크롤을 구현했습니다.
> image 로딩 시 스켈레톤 이미지를 띄워 css가 깨지지 않게 조정했습니다.
> 최신순, 오래된 순을 잠시 보류했습니다.

### 스크린샷
![무한 스크롤](https://github.com/user-attachments/assets/dbe68288-7b54-478d-8fcd-02dfcc5e3c75)
- 무한 스크롤

---
![로딩 전](https://github.com/user-attachments/assets/c73d6160-a9a0-4e12-95eb-e90c9de6ce3f)
- 스켈레톤 이미지 전


![로딩 후](https://github.com/user-attachments/assets/81041238-7a8b-4a33-8274-e100f599b939)
- 스켈레톤 이미지 후


## 💬리뷰 요구사항

- 정렬(최신순, 오래된 순)에 고민이 있어 잠시 로직을 삭제했었는데, 정렬 방식을 선택하면 전체를 리렌더링하여 스크롤을 상단으로 돌리게끔 구현하도록 하겠습니다.
- 전체적으로 데이터 패칭 전에 컴포넌트가 순간적으로 렌더링되는 현상을 잡아야될 것 같습니다. (특히 마이페이지, 결과 페이지)