### PR TITLE
Fix: vite proxy 설정

### DIFF
--- a/.husky/_/post-merge
+++ b/.husky/_/post-merge
@@ -1,7 +1,2 @@
 #!/usr/bin/env sh
-. "$(dirname "$0")/husky.sh"
-
-echo "📦 Starting package installation after pull/merge..."
-npm install
-echo "✅ Package installation completed!"
-exit 0
+. "$(dirname "$0")/h"

--- a/.husky/_/pre-push
+++ b/.husky/_/pre-push
@@ -1,13 +1,2 @@
 #!/usr/bin/env sh
-. "$(dirname "$0")/husky.sh"
-
-echo "Running pre-push checks..."
-
-echo "📦 Building the project..."
-npm run build:test || {
-    echo "❌ Build failed. Please fix the build errors before pushing."
-    exit 1
-}
-
-echo "✅ Pre-push checks passed!"
-exit 0
+. "$(dirname "$0")/h"

--- a/src/components/functional/convert-to-webp.ts
+++ b/src/components/functional/convert-to-webp.ts
@@ -1,6 +1,17 @@
 export const convertToWebP = async (url: string): Promise<Blob | undefined> => {
   try {
-    url = url.replace("https://oaidalleapiprodscus.blob.core.windows.net", "");
+    console.log("변환 시작:", url); // 디버깅
+
+    const baseUrl =
+      process.env.NODE_ENV === "development"
+        ? "http://localhost:5173/proxy"
+        : "https://oaidalleapiprodscus.blob.core.windows.net";
+
+    url = url.replace(
+      "https://oaidalleapiprodscus.blob.core.windows.net",
+      baseUrl,
+    );
+    console.log("수정된 URL:", url); // 디버깅
 
     const response = await fetch(url);
     const blob = await response.blob();

--- a/src/pages/Generate.tsx
+++ b/src/pages/Generate.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { v4 as uuidv4 } from "uuid";
-import Loading from "../components/ui/loading";
+import Loading from "../components/ui/Loading";
 import { profileGenerate } from "../services/profile-generate";
 import { convertToWebP } from "../components/functional/convert-to-webp";
 import { uploadImageToFirebase } from "../services/upload-image-to-firebase";

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -1,17 +1,17 @@
 import React, { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useAuth } from "../contexts/auth-context";
-import Picture from "../components/ui/picture";
+import Picture from "../components/ui/Picture";
 import Kakaoshare from "../components/functional/kakao-share";
 import NavigateToSurvey from "../components/functional/navigate-to-survey-props";
 import { PreventDefaultWrapper } from "../components/functional/prevent-default-wrapper";
-import { Button } from "../components/ui/button";
+import { Button } from "../components/ui/Button";
 import { Text } from "../components/ui/text";
 import { FlexBox } from "../components/ui/flexbox";
-import { Main } from "../components/ui/main";
+import { Main } from "../components/ui/Main";
 import { doc, getDoc, DocumentData } from "firebase/firestore";
 import { db } from "../firebase";
-import { Header } from "../components/ui/header";
+import { Header } from "../components/ui/Header";
 import { useResponsive } from "../hooks/use-responsive";
 
 interface ProfileTypes {

--- a/src/pages/Survey.tsx
+++ b/src/pages/Survey.tsx
@@ -3,14 +3,14 @@ import {
   SurveyTypes,
   surveyContentsMen,
   surveyContentsWomen,
-} from "../components/utils/survey";
+} from "../components/utils/Survey";
 import { useLocation, useNavigate } from "react-router-dom";
-import { Button } from "../components/ui/button";
-import { Header } from "../components/ui/header";
+import { Button } from "../components/ui/Button";
+import { Header } from "../components/ui/Header";
 import { ProgressBar } from "../styles/styled";
 import { FlexBox } from "../components/ui/flexbox";
 import { Text } from "../components/ui/text";
-import { Main } from "../components/ui/main";
+import { Main } from "../components/ui/Main";
 import styled, { keyframes } from "styled-components";
 
 const slideInRight = keyframes`

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,17 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-export default defineConfig ({
-	plugins: [react()],
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      // /"proxy"로 시작하는 프록시 요청
+      "/proxy": {
+        target: "https://oaidalleapiprodscus.blob.core.windows.net",
+        changeOrigin: true,
+        secure: true,
+        rewrite: (path) => path.replace(/^\/proxy/, ""), // 전달된 요청에서 "/proxy"를 제거
+      },
+    },
+  },
 });


### PR DESCRIPTION
## 📝작업 내용

> **vite proxy 설정으로 cors 에러를 해결했습니다.**

vite 마이그레이션 후, 로컬 개발모드에서 이미지 생성 요청 도중 webP 변환 과정에서 중단되는 문제가 있었습니다. 문제 분석 결과, `convert-to-webP` 로직에서 다시 패치한 url 주소가 cors 정책에 의해 접근이 불가능함을 확인했습니다.

이에 `vite.config.ts` 파일에 프록시 설정을 추가하고, `convert-to-webP` 로직에서 `baseUrl`를 설정해 개발 모드와 배포 모드에서 각기 다른 주소로 요청을 보내도록 수정했습니다.