### PR TITLE
feat: useGuestMode

### DIFF
--- a/src/components/functional/navigate-to-survey-props.tsx
+++ b/src/components/functional/navigate-to-survey-props.tsx
@@ -3,17 +3,24 @@ import {useNavigate} from 'react-router-dom';
 import {getCountAndTimeLeft} from '../../services/count-service';
 import {useAuth} from '../../contexts/auth-context';
 import {Button} from '../ui/button';
+import {useGuestMode} from '../../hooks/use-guest-mode';
 
 interface NavigateToSurveyProps {
   label: string;
+  isGuestMode?: boolean;
 }
 
-const NavigateToSurvey = ({label}: NavigateToSurveyProps) => {
+const NavigateToSurvey = ({label, isGuestMode}: NavigateToSurveyProps) => {
   const navigate = useNavigate();
+  const [guestMode, setGuestMode] = useGuestMode();
   const {currentUser} = useAuth();
 
   const handleSurveyNavigation = async () => {
     const {count, limit, timeLeft} = await getCountAndTimeLeft(currentUser);
+
+    if (isGuestMode) {
+      setGuestMode('true');
+    }
 
     if (count < limit) {
       navigate('/genderselect');

--- a/src/hooks/use-guest-mode.ts
+++ b/src/hooks/use-guest-mode.ts
@@ -1,0 +1,28 @@
+import {useSyncExternalStore} from 'react';
+
+type GuestModeType = 'true' | 'false';
+
+const getGuestModeLocalStorage = () => {
+  return localStorage.getItem('GUEST_MODE');
+};
+
+const subscribe = (callback: () => void) => {
+  window.addEventListener('storage', callback);
+  return () => {
+    window.removeEventListener('storage', callback);
+  };
+};
+
+export const useGuestMode = (): [
+  string | null,
+  (isGuestMode: GuestModeType) => void,
+] => {
+  const guestMode = useSyncExternalStore(subscribe, getGuestModeLocalStorage);
+
+  const setGuestMode = (isGuestMode: GuestModeType) => {
+    localStorage.setItem('GUEST_MODE', isGuestMode.toString());
+    window.dispatchEvent(new Event('storage'));
+  };
+
+  return [guestMode, setGuestMode] as const;
+};

--- a/src/pages/Generate.tsx
+++ b/src/pages/Generate.tsx
@@ -1,7 +1,7 @@
-import React, {useState, useEffect} from 'react';
+import React, {useEffect} from 'react';
 import {useLocation, useNavigate} from 'react-router-dom';
 import {v4 as uuidv4} from 'uuid';
-import Loading from '../components/ui/Loading';
+import Loading from '../components/ui/loading';
 import {profileGenerate} from '../services/profile-generate';
 import {convertToWebP} from '../components/functional/convert-to-webp';
 import {uploadImageToFirebase} from '../services/upload-image-to-firebase';
@@ -10,12 +10,13 @@ import {doc, setDoc, getDoc} from 'firebase/firestore';
 import {db} from '../firebase';
 import {imageGenerate} from '../services/image-generate';
 import {getCountAndTimeLeft, incrementCount} from '../services/count-service';
+import {useGuestMode} from '../hooks/use-guest-mode';
 
 const Generate = () => {
   const location = useLocation();
+  const [guestMode, setGuestMode] = useGuestMode();
   const navigate = useNavigate();
   const {currentUser} = useAuth();
-  const [progressState, setProgressState] = useState<number>(0);
 
   useEffect(() => {
     const {prompts, hashTags} = location.state;
@@ -29,30 +30,9 @@ const Generate = () => {
 
     const processAndNavigate = async () => {
       try {
-        let currentProgress = 0;
         const newPostId = uuidv4();
 
-        // 진행률을 부드럽게 업데이트하는 함수
-        const updateProgressSmoothly = async (
-          targetProgress: number,
-          duration: number,
-        ) => {
-          const totalSteps = Math.floor(duration / 100);
-          const progressIncrement =
-            (targetProgress - currentProgress) / totalSteps;
-
-          for (let i = 0; i < totalSteps; i++) {
-            currentProgress = Math.min(
-              currentProgress + progressIncrement,
-              targetProgress,
-            );
-            setProgressState(Math.round(currentProgress));
-            await new Promise((resolve) => setTimeout(resolve, 200));
-          }
-        };
-
         // 1. 이미지 생성 시작
-        await updateProgressSmoothly(50, 8000);
         const data = await imageGenerate(prompts);
         const responseUrl = data?.url;
         if (!responseUrl) throw new Error('이미지 URL 생성 실패');
@@ -62,26 +42,38 @@ const Generate = () => {
         if (!webP) throw new Error('WebP 변환 실패');
 
         const imageUploadPromise = uploadImageToFirebase(webP);
-        await updateProgressSmoothly(70, 2000);
         const imageUrl = await imageUploadPromise;
         if (!imageUrl) throw new Error('이미지 업로드 실패');
 
         // 3. 프로필 생성
         const profilePromise = profileGenerate(prompts);
-        await updateProgressSmoothly(90, 2000);
         const profile = await profilePromise;
         if (!profile) throw new Error('프로필 생성 실패');
 
         // 4. Firebase에 게시물 저장
-        await setDoc(doc(db, 'posts', newPostId), {
-          id: newPostId,
-          userId: currentUser?.uid || null,
-          email: currentUser?.email || null,
-          imageUrl: imageUrl,
-          createdAt: new Date(),
-          hashTags: hashTags,
-          profile: profile,
-        });
+        if (guestMode === 'true') {
+          await setDoc(doc(db, 'anonymous_posts', newPostId), {
+            id: newPostId,
+            createdAt: new Date(),
+            imageUrl: imageUrl,
+            profile: profile,
+            hashTags: hashTags,
+            prompts: prompts,
+            userId: null,
+            email: null,
+          });
+        } else {
+          await setDoc(doc(db, 'posts', newPostId), {
+            id: newPostId,
+            createdAt: new Date(),
+            imageUrl: imageUrl,
+            profile: profile,
+            hashTags: hashTags,
+            prompts: prompts,
+            userId: currentUser?.uid,
+            email: currentUser?.email,
+          });
+        }
 
         // 5. 사용자 문서 업데이트 (로그인된 경우)
         if (currentUser) {
@@ -106,7 +98,6 @@ const Generate = () => {
         }
 
         // 7. 최종 진행률 업데이트 및 결과 페이지 이동
-        await updateProgressSmoothly(100, 1000);
         if (!imageUrl || !profile) {
           throw new Error('이미지 URL 또는 프로필이 누락되었습니다.');
         }
@@ -129,7 +120,7 @@ const Generate = () => {
 
   return (
     <>
-      <Loading progressState={progressState} />
+      <Loading progressState={0} />
     </>
   );
 };

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -105,7 +105,7 @@ const Home = () => {
         >
           로그인하기
         </Button>
-        <NavigateToSurvey label='로그인 없이 시작' />
+        <NavigateToSurvey label='로그인 없이 시작' isGuestMode={true} />
       </FlexBox>
       <FlexBox direction='column' gap='8rem'>
         <div>


### PR DESCRIPTION
## 📝작업 내용

> useGuestMode라는 훅으로, 로그인 없이 사용하는 유저를 판별하는 로직을 만들었습니다.
> `useSyncExternalStore`라는 훅을 사용해 로컬 스토리지를 리액트의 상태처럼 관리할 수 있습니다.
> 해당 결과물은 anonymous_posts라는 DB에 저장됩니다.
> 원활한 작업을 위해 `progressbar`을 로직에서 제거했습니다.

## 💬리뷰 요구사항(선택)
### 1. guestMode 분기를 언제 나눌까에 대한 고민

- 현재는 '로그인 없이 시작하기'를 누르면 `guestMode: true`로 설정됩니다. 그 후 survey에서 한번 더 guestMode인지 확인 후 저장 할 DB를 나눕니다. 

- 더 나은 방향이 있을 것 같은데 아직 잘 모르겠습니다. 수요일날 혹시 좋은 의견 있다면 공유 부탁드립니다.

### 2. 굳이 이 훅을 사용해야할까?

- 해당 훅은 리액트 외부 (session, localstorage 등)의 상태들을 리액트의 상태처럼 등록하여 리액트의 상태변화처럼 컴포넌트를 리렌더링 시킨다는 메커니즘인데, 이 프로젝트에서는 localstorage를 굳이 상태로 관리해야할까? 라는 의문이 생겼습니다. 로컬 스토리지로 이루어지는 인터렉션이 없기 때문입니다.

- 물론 커스텀 훅으로 사용되어 재사용성이 높고 보일러 플레이트 코드가 줄어든다는 것이 장점인데 해당 고민이 있어 다른분들은 어떻게 생각하실지 의견 나눠보고자 글 남깁니다...!