### PR TITLE
fix: text color 템플릿 리터럴 적용 안되는 버그 해결

### DIFF
--- a/src/components/ui/text.tsx
+++ b/src/components/ui/text.tsx
@@ -5,10 +5,17 @@ import { twMerge } from 'tailwind-merge';
 export interface TextProps {
   fontSize?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
   fontWeight?: 'normal' | 'bold' | 'medium' | 'light';
-  color?: string; // e.g., Tailwind color classes or custom colors
+  color?: 'black' | 'red' | 'white' | 'main';
   className?: string;
   children?: React.ReactNode;
 }
+
+const colorMap: Record<NonNullable<TextProps['color']>, string> = {
+  black: 'text-black',
+  red: 'text-red',
+  white: 'text-white',
+  main: 'text-main',
+};
 
 const fontSizeMap: Record<NonNullable<TextProps['fontSize']>, string> = {
   xs: 'text-xs', // 12px
@@ -29,16 +36,15 @@ const fontWeightMap: Record<NonNullable<TextProps['fontWeight']>, string> = {
 export const Text = ({
   fontSize = 'md',
   fontWeight = 'normal',
-  color = 'inherit',
+  color = 'black',
   className,
   children,
 }: TextProps) => {
-  // 이 코드도 기본 스타일과 조건부 스타일을 나누어 진행하면 코드 가독성이 더 좋아질 것 같습니다!
   const baseStyles = 'leading-normal';
   const conditionalStyles = clsx(
     fontSizeMap[fontSize],
     fontWeightMap[fontWeight],
-    color !== 'inherit' && `text-${color}`,
+    colorMap[color],
   );
 
   const classes = twMerge(baseStyles, conditionalStyles, className);


### PR DESCRIPTION
## 📝작업 내용

> tailwind 공식문서에서 props를 사용하여 클래스 이름을 동적으로 작성하지 말라고 명시되어 있었습니다.
> 따라서, 기존 코드와 일관성 있게 객체를 활용하여 props를 정적 클래스 이름에 매핑하도록 수정하였습니다.

## 💬리뷰 요구사항(선택)
1. 해당 내용이 명시된 공식문서 링크 첨부했습니다.
> https://tailwindcss.com/docs/detecting-classes-in-source-files

2. 회원가입에서 유효성검사 에러가 잘 적용되는지 확인하는 과정에서, 현재 input에 입력시 실시간으로 에러 표시해주지 않고 form 제출 버튼을 클릭했을 때 에러 표시해주는 것으로 확인했습니다. 
사용자 관점에서 실시간으로 에러 표시해주는 방향을 고려해봐도 좋을 것 같습니다!
`mode: 'onChange'` 를 추가하면 실시간으로 에러 표시 가능합니다.