### PR TITLE
Refactor: generate 로직 개편, result 로직 분기 개편 / Feat: 로그인 시 데이터 마이그레이션 로직 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { Home, Survey, Result, GenderSelect } from './pages';
 import { AuthProvider, useAuth } from './contexts/auth-context';
 import ErrorBoundary from './components/functional/error-boudary';
 import { LandingRoute } from './components/functional/landing-route';
+import { CookiesProvider } from 'react-cookie';
 
 const Generate = lazy(() => import('./pages/generate'));
 const MyPage = lazy(() => import('./pages/mypage'));
@@ -56,31 +57,33 @@ const routes = [
 
 const App = () => {
   return (
-    <QueryClientProvider client={queryClient}>
-      <AuthProvider>
-        <ErrorBoundary fallback={<div>에러가 발생했습니다.</div>}>
-          <Router>
-            <Routes>
-              {routes.map(({ path, element, suspense }) => (
-                <Route
-                  key={path}
-                  path={path}
-                  element={
-                    suspense ? (
-                      <Suspense fallback={<div>Loading...</div>}>
-                        {element}
-                      </Suspense>
-                    ) : (
-                      element
-                    )
-                  }
-                />
-              ))}
-            </Routes>
-          </Router>
-        </ErrorBoundary>
-      </AuthProvider>
-    </QueryClientProvider>
+    <CookiesProvider>
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <ErrorBoundary fallback={<div>에러가 발생했습니다.</div>}>
+            <Router>
+              <Routes>
+                {routes.map(({ path, element, suspense }) => (
+                  <Route
+                    key={path}
+                    path={path}
+                    element={
+                      suspense ? (
+                        <Suspense fallback={<div>Loading...</div>}>
+                          {element}
+                        </Suspense>
+                      ) : (
+                        element
+                      )
+                    }
+                  />
+                ))}
+              </Routes>
+            </Router>
+          </ErrorBoundary>
+        </AuthProvider>
+      </QueryClientProvider>
+    </CookiesProvider>
   );
 };
 export default App;

--- a/src/components/ui/header.tsx
+++ b/src/components/ui/header.tsx
@@ -7,17 +7,20 @@ import { auth } from '../../firebase';
 import { signOut } from 'firebase/auth';
 import { useMediaQuery } from 'usehooks-ts';
 import { FlexBox } from './flexbox';
+import { useGuestMode } from '../../hooks/use-guest-mode';
 
 export const Header = () => {
   const isMobile = useMediaQuery('(max-width: 768px)');
   const navigate = useNavigate();
   const { currentUser } = useAuth();
+  const [_, setGuestMode] = useGuestMode();
 
   const handleLogout = async () => {
     const confirmation = window.confirm('로그아웃 하시겠습니까?');
     if (confirmation) {
       try {
         await signOut(auth);
+        setGuestMode(true);
         navigate('/');
       } catch (error) {
         console.error('Logout failed', error);

--- a/src/components/utils/cookies.ts
+++ b/src/components/utils/cookies.ts
@@ -1,0 +1,22 @@
+import { Cookies } from 'react-cookie';
+
+export const COOKIE_NAMES = {
+  GUEST_MODE: 'GUEST_MODE',
+  POST_ID: 'POST_ID',
+} as const;
+
+const cookies = new Cookies();
+
+export const setCookie = (name: string, value: string, options?: any) => {
+  return cookies.set(name, value, { ...options });
+};
+
+export const getCookie = (name: string) => {
+  return cookies.get(name);
+};
+
+// URL에서 postId를 추출하는 함수
+export const extractPostIdFromUrl = (): string => {
+  const pathSegments = window.location.pathname.split('/');
+  return pathSegments[pathSegments.length - 1];
+};

--- a/src/components/utils/cookies.ts
+++ b/src/components/utils/cookies.ts
@@ -7,16 +7,28 @@ export const COOKIE_NAMES = {
 
 const cookies = new Cookies();
 
-export const setCookie = (name: string, value: string, options?: any) => {
-  return cookies.set(name, value, { ...options });
+type CookieOptions = {
+  path?: string;
+  maxAge?: number;
+  secure?: boolean;
+  sameSite?: 'strict' | 'lax' | 'none';
+};
+
+export const setCookie = (
+  name: string,
+  value: string | boolean,
+  options?: CookieOptions,
+) => {
+  // boolean 값은 문자열로 변환하여 저장
+  const valueToStore = typeof value === 'boolean' ? String(value) : value;
+  return cookies.set(name, valueToStore, { ...options });
 };
 
 export const getCookie = (name: string) => {
-  return cookies.get(name);
-};
-
-// URL에서 postId를 추출하는 함수
-export const extractPostIdFromUrl = (): string => {
-  const pathSegments = window.location.pathname.split('/');
-  return pathSegments[pathSegments.length - 1];
+  const value = cookies.get(name);
+  // GUEST_MODE인 경우에만 boolean으로 변환
+  if (name === COOKIE_NAMES.GUEST_MODE) {
+    return value === 'true';
+  }
+  return value;
 };

--- a/src/components/utils/post-migration.ts
+++ b/src/components/utils/post-migration.ts
@@ -1,0 +1,47 @@
+import type { UserCredential } from 'firebase/auth';
+import { getDoc, doc, setDoc, deleteDoc } from 'firebase/firestore';
+import { db } from '../../firebase';
+import { COOKIE_NAMES, getCookie, setCookie } from './cookies';
+
+export const handleGuestPostMigration = async (
+  currentUser: UserCredential['user'],
+) => {
+  const guestPostId = getCookie(COOKIE_NAMES.POST_ID);
+
+  if (guestPostId) {
+    try {
+      // anonymous_posts에서 데이터 가져오기
+      const anonymousRef = doc(db, 'anonymous_posts', guestPostId);
+      const anonymousDoc = await getDoc(anonymousRef);
+
+      if (anonymousDoc.exists()) {
+        const postData = anonymousDoc.data();
+
+        // posts 컬렉션으로 데이터 이동
+        await setDoc(doc(db, 'posts', guestPostId), {
+          ...postData,
+          userId: currentUser.uid,
+          email: currentUser.email,
+        });
+
+        // anonymous_posts에서 데이터 삭제
+        await deleteDoc(anonymousRef);
+
+        // 사용자의 postList에 추가
+        const userRef = doc(db, 'users', currentUser.uid);
+        const userDoc = await getDoc(userRef);
+
+        if (userDoc.exists()) {
+          const userData = userDoc.data();
+          const newPostList = [guestPostId, ...(userData.postList || [])];
+          await setDoc(userRef, { postList: newPostList }, { merge: true });
+        }
+
+        // postId 쿠키 삭제
+        setCookie(COOKIE_NAMES.POST_ID, '', { maxAge: -1 });
+      }
+    } catch (error) {
+      console.error('게스트 포스트 이전 중 오류 발생:', error);
+    }
+  }
+};

--- a/src/pages/generate.tsx
+++ b/src/pages/generate.tsx
@@ -1,111 +1,58 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
 import { profileGenerate } from '../services/profile-generate';
-import { convertToWebP } from '../components/functional/convert-to-webp';
-import { uploadImageToFirebase } from '../services/upload-image-to-firebase';
 import { useAuth } from '../contexts/auth-context';
-import { doc, setDoc, getDoc } from 'firebase/firestore';
-import { db } from '../firebase';
 import { imageGenerate } from '../services/image-generate';
-import { getCountAndTimeLeft, incrementCount } from '../services/count-service';
-import { useGuestMode } from '../hooks/use-guest-mode';
 import LoadingScreen from '../components/ui/loading-screen';
 
 const Generate = () => {
   const location = useLocation();
-  const [guestMode, setGuestMode] = useGuestMode();
   const navigate = useNavigate();
-  const { currentUser } = useAuth();
   const [isLoading, setIsLoading] = useState(true);
+  const { currentUser } = useAuth();
 
   useEffect(() => {
     const { prompts, hashTags } = location.state;
+    const newPostId = uuidv4();
 
     const blockBackButton = () => {
       window.history.pushState(null, '', window.location.href);
     };
-
     window.history.pushState(null, '', window.location.href);
     window.addEventListener('popstate', blockBackButton);
 
     const processAndNavigate = async () => {
       try {
-        const newPostId = uuidv4();
+        // 이미지 생성과 프로필 생성을 병렬로 처리
+        const [imageData, profileData] = await Promise.all([
+          imageGenerate(prompts),
+          profileGenerate(prompts),
+        ]);
 
-        // 1. 이미지 생성 시작
-        const data = await imageGenerate(prompts);
-        const responseUrl = data?.url;
-        if (!responseUrl) throw new Error('이미지 URL 생성 실패');
-
-        // 2. WebP 변환
-        const webP = await convertToWebP(responseUrl);
-        if (!webP) throw new Error('WebP 변환 실패');
-
-        const imageUploadPromise = uploadImageToFirebase(webP);
-        const imageUrl = await imageUploadPromise;
-        if (!imageUrl) throw new Error('이미지 업로드 실패');
-
-        // 3. 프로필 생성
-        const profilePromise = profileGenerate(prompts);
-        const profile = await profilePromise;
-        if (!profile) throw new Error('프로필 생성 실패');
-
-        // 4. Firebase에 게시물 저장
-        if (guestMode === 'true') {
-          await setDoc(doc(db, 'anonymous_posts', newPostId), {
-            id: newPostId,
-            createdAt: new Date(),
-            imageUrl: imageUrl,
-            profile: profile,
-            hashTags: hashTags,
-            prompts: prompts,
-            userId: null,
-            email: null,
-          });
-        } else {
-          await setDoc(doc(db, 'posts', newPostId), {
-            id: newPostId,
-            createdAt: new Date(),
-            imageUrl: imageUrl,
-            profile: profile,
-            hashTags: hashTags,
-            prompts: prompts,
-            userId: currentUser?.uid,
-            email: currentUser?.email,
-          });
+        if (!imageData?.url || !profileData) {
+          throw new Error('이미지 또는 프로필 생성 실패');
         }
 
-        // 5. 사용자 문서 업데이트 (로그인된 경우)
-        if (currentUser) {
-          const userRef = doc(db, 'users', currentUser.uid);
-          const userSnapShot = await getDoc(userRef);
+        // profileData를 JSON으로 파싱
+        const parsedProfile =
+          typeof profileData === 'string'
+            ? JSON.parse(profileData)
+            : profileData;
 
-          if (userSnapShot.exists()) {
-            const userData = userSnapShot.data();
-            const newPostList = [newPostId, ...(userData.postList || [])];
-            await setDoc(
-              doc(db, 'users', currentUser.uid),
-              {
-                postList: newPostList,
-              },
-              { merge: true },
-            );
-          }
-
-          // 6. 카운트 업데이트
-          const { count, limit } = await getCountAndTimeLeft(currentUser);
-          await incrementCount(currentUser, count, limit);
-        }
-
-        // 7. 최종 진행률 업데이트 및 결과 페이지 이동
         setIsLoading(false);
-        if (!imageUrl || !profile) {
-          throw new Error('이미지 URL 또는 프로필이 누락되었습니다.');
-        }
 
+        // 생성된 결과와 함께 result 페이지로 이동
         navigate(`/result/${newPostId}`, {
           replace: true,
+          state: {
+            tempImageUrl: imageData.url,
+            profile: parsedProfile,
+            hashTags,
+            prompts,
+            postId: newPostId,
+            isLoggedIn: !!currentUser,
+          },
         });
       } catch (error) {
         console.error(error);
@@ -114,11 +61,10 @@ const Generate = () => {
 
     processAndNavigate();
 
-    // 컴포넌트 언마운트 시 뒤로 가기 이벤트 리스너 제거
     return () => {
       window.removeEventListener('popstate', blockBackButton);
     };
-  }, [location, currentUser, navigate]);
+  }, [location, navigate, currentUser]);
 
   return (
     <div className='w-full min-h-screen'>
@@ -126,5 +72,4 @@ const Generate = () => {
     </div>
   );
 };
-
 export default Generate;

--- a/src/pages/result.tsx
+++ b/src/pages/result.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useEffect, useState, useCallback } from 'react';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../contexts/auth-context';
 import Picture from '../components/ui/picture';
 import Kakaoshare from '../components/functional/kakao-share';
@@ -9,10 +9,18 @@ import { Button } from '../components/ui/button/button';
 import { Text } from '../components/ui/text';
 import { FlexBox } from '../components/ui/flexbox';
 import { Main } from '../components/ui/main';
-import { doc, getDoc, DocumentData } from 'firebase/firestore';
+import { doc, setDoc, getDoc } from 'firebase/firestore';
 import { db } from '../firebase';
 import { Header } from '../components/ui/header';
 import { useResponsive } from '../hooks/use-responsive';
+import { convertToWebP } from '../components/functional/convert-to-webp';
+import { uploadImageToFirebase } from '../services/upload-image-to-firebase';
+import { getCountAndTimeLeft, incrementCount } from '../services/count-service';
+import {
+  COOKIE_NAMES,
+  setCookie,
+  getCookie,
+} from '../components/utils/cookies';
 
 interface ProfileTypes {
   name: string;
@@ -22,69 +30,173 @@ interface ProfileTypes {
   hobbies: string;
 }
 
+interface PostData {
+  id: string;
+  createdAt: Date;
+  imageUrl: string;
+  profile: string;
+  hashTags: string[];
+  prompts: string[];
+  userId: string | null;
+  email: string | null;
+}
+
 const Result = () => {
   const { postId } = useParams();
+  const location = useLocation();
+  const {
+    tempImageUrl,
+    profile: initialProfile,
+    hashTags,
+    prompts,
+  } = location.state || {};
+  const [imageUrl, setImageUrl] = useState(tempImageUrl);
+  const [profile, setProfile] = useState<ProfileTypes | null>(initialProfile);
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const { currentUser } = useAuth();
   const isMobile = useResponsive();
-  const [post, setPost] = useState<DocumentData | null>(null);
-  const [profile, setProfile] = useState<ProfileTypes | null>(null);
-  const currentUser = useAuth();
   const navigate = useNavigate();
-  const isLogin = currentUser.currentUser;
 
-  useEffect(() => {
-    const fetchPost = async () => {
-      if (postId) {
-        try {
-          const postDocRef = doc(db, 'posts', postId);
-          const postSnapshot = await getDoc(postDocRef);
+  const isGuest = getCookie(COOKIE_NAMES.GUEST_MODE) === true;
+  const collection = isGuest ? 'anonymous_posts' : 'posts';
 
-          if (!postSnapshot.exists()) return;
+  const fetchPostData = useCallback(
+    async (postId: string) => {
+      if (!postId) return;
 
-          setPost(postSnapshot.data());
-        } catch (error) {
-          console.error('Error fetching document: ', error);
+      try {
+        const postRef = doc(db, collection, postId);
+        const postDoc = await getDoc(postRef);
+
+        if (postDoc.exists()) {
+          const data = postDoc.data();
+          setImageUrl(data.imageUrl);
+          setProfile(
+            typeof data.profile === 'string'
+              ? JSON.parse(data.profile)
+              : data.profile,
+          );
         }
+      } catch (error) {
+        console.error('게시물 데이터 로딩 실패:', error);
+        setError('데이터를 불러오는데 실패했습니다.');
+      }
+    },
+    [collection],
+  );
+
+  // 초기 데이터 가져오기
+  useEffect(() => {
+    if (!location.state && postId) {
+      fetchPostData(postId);
+    }
+  }, [location.state, postId, fetchPostData]);
+
+  // 백그라운드 작업
+  useEffect(() => {
+    const processBackgroundTasks = async () => {
+      if (!postId || !tempImageUrl) return;
+      setIsProcessing(true);
+
+      try {
+        const actualPostId = postId;
+        const collection = isGuest ? 'anonymous_posts' : 'posts';
+
+        // 이미 저장된 데이터인지 확인
+        const existingDoc = await getDoc(doc(db, collection, actualPostId));
+        if (existingDoc.exists()) {
+          setIsProcessing(false);
+          return;
+        }
+
+        // 새 데이터 저장 로직
+        const webP = await convertToWebP(tempImageUrl);
+        if (!webP) throw new Error('WebP 변환 실패');
+
+        const uploadedImageUrl = await uploadImageToFirebase(webP);
+        if (!uploadedImageUrl) throw new Error('이미지 업로드 실패');
+
+        setImageUrl(uploadedImageUrl);
+
+        const profileToSave =
+          typeof profile === 'string' ? profile : JSON.stringify(profile);
+
+        const postData: PostData = {
+          id: actualPostId,
+          createdAt: new Date(),
+          imageUrl: uploadedImageUrl,
+          profile: profileToSave,
+          hashTags: hashTags || [],
+          prompts: prompts || [],
+          userId: currentUser?.uid || null,
+          email: currentUser?.email || null,
+        };
+
+        await setDoc(doc(db, collection, actualPostId), postData);
+
+        // 게스트 모드인 경우 쿠키에 postId 저장
+        if (isGuest) {
+          setCookie(COOKIE_NAMES.POST_ID, actualPostId, {
+            maxAge: 7 * 24 * 60 * 60, // 7일간 유지
+            path: '/',
+            secure: true,
+            sameSite: 'strict',
+          });
+        }
+
+        // 로그인 사용자의 경우 추가 처리 - Firebase 문서 업데이트
+        else if (currentUser) {
+          const userRef = doc(db, 'users', currentUser.uid);
+          const userSnapShot = await getDoc(userRef);
+
+          if (userSnapShot.exists()) {
+            const userData = userSnapShot.data();
+            const newPostList = [postId, ...(userData.postList || [])];
+            await setDoc(
+              doc(db, 'users', currentUser.uid),
+              { postList: newPostList },
+              { merge: true },
+            );
+          }
+        }
+        // 카운트 증가
+        const { count, limit } = await getCountAndTimeLeft(currentUser);
+        await incrementCount(currentUser, count, limit);
+      } catch (error) {
+        console.error('Background processing error:', error);
+        setError('처리 중 오류가 발생했습니다.');
+      } finally {
+        setIsProcessing(false);
       }
     };
 
-    fetchPost();
-  }, [postId]);
+    if (location.state) {
+      processBackgroundTasks();
+    }
+  }, [
+    location.state,
+    postId,
+    currentUser,
+    tempImageUrl,
+    profile,
+    hashTags,
+    prompts,
+    isGuest,
+  ]);
 
-  useEffect(() => {
-    if (!post) return;
-
-    const jsonData = JSON.parse(post.profile);
-    setProfile(jsonData);
-  }, [post]);
-
-  // 뒤로가기 방지
-  useEffect(() => {
-    const blockBackButton = () => {
-      window.history.pushState(null, '', window.location.href);
-    };
-
-    window.history.pushState(null, '', window.location.href);
-    window.addEventListener('popstate', blockBackButton);
-
-    return () => {
-      window.removeEventListener('popstate', blockBackButton);
-    };
-  }, []);
-
+  // 이미지 다운로드 및 WebP 변환
   const handleDownload = async () => {
     try {
-      const response = await fetch(post?.imageUrl);
+      const response = await fetch(imageUrl);
       if (!response.ok) {
         throw new Error('Network response was not ok');
       }
       const blob = await response.blob();
-
       const canvas = document.createElement('canvas');
       const ctx = canvas.getContext('2d');
-
       const img = new Image();
       img.src = URL.createObjectURL(blob);
-
       img.onload = () => {
         canvas.width = img.width;
         canvas.height = img.height;
@@ -105,6 +217,21 @@ const Result = () => {
     }
   };
 
+  // 뒤로가기 방지
+  useEffect(() => {
+    const blockBackButton = () => {
+      window.history.pushState(null, '', window.location.href);
+    };
+
+    window.history.pushState(null, '', window.location.href);
+    window.addEventListener('popstate', blockBackButton);
+
+    return () => {
+      window.removeEventListener('popstate', blockBackButton);
+    };
+  }, []);
+
+  // 링크 공유
   const handleShare = async () => {
     try {
       await navigator.clipboard.writeText(window.location.href);
@@ -130,12 +257,18 @@ const Result = () => {
       <Main isMobile={isMobile}>
         <PreventDefaultWrapper>
           <FlexBox direction='column'>
-            <Picture imageUrl={post?.imageUrl} altText='이상형 이미지' />
-            {isLogin && (
+            <Picture imageUrl={imageUrl} altText='이상형 이미지' />
+            {isProcessing && (
+              <Text fontSize='sm' className='text-gray-500 mt-2 text-center'>
+                이미지 최적화 처리 중...
+              </Text>
+            )}
+            {currentUser && (
               <Button
                 bgColor='white'
                 className='text-black p-3 text-sm font-bold'
                 onClick={handleDownload}
+                disabled={isProcessing}
               >
                 ⤓ 내 이상형 사진 소장하기
               </Button>
@@ -167,7 +300,7 @@ const Result = () => {
             이상형의 취향을 저격할 수 있는 데이트코스를 계획해보세요!
           </Text>
           <FlexBox style={{ marginBottom: '2rem' }}>
-            {isLogin ? (
+            {currentUser ? (
               <>
                 <NavigateToSurvey label='이상형 다시 찾기' />
               </>
@@ -176,12 +309,14 @@ const Result = () => {
                 <p className='text-gray'>
                   사진을 저장하고 기록하고 싶다면 로그인 해보세요
                 </p>
-                <Button onClick={() => navigate('/')}>로그인</Button>
+                <Button bgColor='main' onClick={() => navigate('/')}>
+                  로그인
+                </Button>
               </>
             )}
           </FlexBox>
           <FlexBox direction='column' className='text-center'>
-            {isLogin && (
+            {currentUser && (
               <Text fontSize='sm' className='mb-4'>
                 ▼ 결과를 친구에게 공유해 보세요! ▼
               </Text>

--- a/src/services/auth/login-with-email.ts
+++ b/src/services/auth/login-with-email.ts
@@ -1,5 +1,6 @@
 import { signInWithEmailAndPassword } from 'firebase/auth';
 import { auth } from '../../firebase';
+import { handleGuestPostMigration } from '../../components/utils/post-migration';
 
 export const loginWithEmail = async (email: string, password: string) => {
   try {
@@ -8,6 +9,7 @@ export const loginWithEmail = async (email: string, password: string) => {
       email,
       password,
     );
+    await handleGuestPostMigration(userCredential.user);
     return userCredential;
   } catch (error) {
     alert('이메일 혹은 비밀번호가 올바르지 않습니다.');

--- a/src/services/auth/login-with-google.ts
+++ b/src/services/auth/login-with-google.ts
@@ -1,6 +1,5 @@
 import {
   signInWithPopup,
-  signInWithRedirect,
   getRedirectResult,
   GoogleAuthProvider,
 } from 'firebase/auth';

--- a/src/services/auth/login-with-google.ts
+++ b/src/services/auth/login-with-google.ts
@@ -3,9 +3,10 @@ import {
   signInWithRedirect,
   getRedirectResult,
   GoogleAuthProvider,
-} from "firebase/auth";
-import { auth } from "../../firebase";
-import { FirebaseError } from "firebase/app";
+} from 'firebase/auth';
+import { auth } from '../../firebase';
+import { FirebaseError } from 'firebase/app';
+import { handleGuestPostMigration } from '../../components/utils/post-migration';
 
 // export const loginWithGoogle = async () => {
 //   const provider = new GoogleAuthProvider();
@@ -29,27 +30,29 @@ export const loginWithGoogle = async () => {
   const provider = new GoogleAuthProvider();
   try {
     const credential = await signInWithPopup(auth, provider);
+    await handleGuestPostMigration(credential.user);
     return credential;
   } catch (error) {
-    console.error("Error during Google login: ", error);
+    console.error('Error during Google login: ', error);
   }
 };
 
 export const handleRedirectResult = async () => {
   try {
     const result = await getRedirectResult(auth);
-    console.log("Redirect result: ", result);
+    console.log('Redirect result: ', result);
     if (result) {
-      const credential = GoogleAuthProvider.credentialFromResult(result);
-      return credential;
+      await handleGuestPostMigration(result.user);
+      return result;
     }
+    return null;
   } catch (error) {
     if (error instanceof FirebaseError) {
       const credential = GoogleAuthProvider.credentialFromError(error);
-      console.error("Error during redirect result handling: ", error);
+      console.error('Error during redirect result handling: ', error);
       return credential;
     } else {
-      console.error("Unexpected error: ", error);
+      console.error('Unexpected error: ', error);
     }
   }
 };

--- a/src/services/auth/logout.ts
+++ b/src/services/auth/logout.ts
@@ -1,13 +1,13 @@
-import { signOut } from "firebase/auth";
-import { auth } from "../../firebase";
+import { signOut } from 'firebase/auth';
+import { auth } from '../../firebase';
 
 export const logout = async () => {
   try {
-    if (confirm("로그아웃 하시겠습니까?")) {
+    if (confirm('로그아웃 하시겠습니까?')) {
       await signOut(auth);
-      console.log("User logged out");
+      console.log('User logged out');
     }
   } catch (error) {
-    console.error("Failed to logout with email: ", error);
+    console.error('Failed to logout with email: ', error);
   }
 };


### PR DESCRIPTION
## 📝작업 내용

> 기존에 generate에서 모두 처리하던 이미지 변환 및 Firebase 저장 로직을 일부 result에서 처리하도록 개편했습니다. 게스트 모드인 경우, result 페이지 비동기 작업 말미에서 쿠키에 `postId`를 저장하는 로직을 구현했습니다. 로그인 시 쿠키 `postId` 유무를 판별하여 해당 데이터를 사용자 계정으로 자동 이전하는 기능을 구현했습니다.

### 1. generate 로직 개편
**`generate.tsx`**
- 이미지와 프로필 생성 작업만 수행하고, 생성된 결과를 그대로 result 페이지로 넘기도록 수정했습니다.
- 이미지 생성과 프로필 생성은 생성 시간 단축을 위해 병렬 작업으로 처리했습니다.

**`result.tsx`**
- 기존에 generate에서 수행하던 이미지 WebP 변환, Firebase 작업을 result 백그라운드에서 처리하도록 수정했습니다.
- 백그라운드 작업 시, 해당 postId가 기존 firebase 컬렉션에 존재하는지 검증 후 새 데이터를 저장하도록 로직의 안정성을 높였습니다.

### 2. result 분기 개편
- 쿠키에 저장된 `GUEST_MODE` 값을 판별하여 게스트/로그인 모드에 따른 분기 처리를 하도록 수정했습니다.
- `GUEST_MODE`가 `true`인 경우, 생성된 `postId`를 쿠키에 저장하도록 구현했습니다.
- 만약 기존 쿠키에 postId가 존재하는데 게스트 모드에서 다시 이미지를 생성할 경우, 쿠키는 새로 생성된 `postId`로 값이 덮어씌워집니다. (게스트 모드는 카운트가 1번이기 때문에 이 경우는 딱히 신경쓰지 않아도 될 것 같습니다.)

### 3. cookie 로직 개선
- 쿠키 관리 관련 로직을 `components/utils/cookies.ts` 파일로 분리했습니다.
- `GUEST_MODE`와 `POST_ID` 값을 통합 관리하고 쿠키 관련 함수 재사용성을 높였습니다.

### 4. 로그인 로직 개선
- 이메일/구글 로그인 시 쿠키에 `POST_ID` 값 유무를 판별해 해당 데이터 컬렉션을 마이그레이션하는 로직을 추가했습니다.
- 쿠키에 `POST_ID`가 존재할 경우, Firebase 컬렉션 간 데이터 이전과 사용자 postList 업데이트가 자동으로 수행됩니다.
- 작업이 완료되면 쿠키에 존재하던 `POST_ID`값이 삭제됩니다.
- 이 함수는 `components/utils/post-migration.ts` 파일로 별도 분리해 코드의 안정성과 가독성을 높였습니다.

### 5. 로그아웃 로직 개선
- 로그아웃 시, `GUEST_MODE`가 `true`로 변경되는 로직을 `header.tsx` 로그아웃 버튼에 추가했습니다.
 
## 💬리뷰 요구사항(선택)
1. result 페이지에서 로그인 여부 판별 방식을 `currentUser`과 쿠키 값 `guestMode`를 혼용해서 사용하고 있습니다. 일단 아무래도 보안성을 고려해서 기존에 `currentUser`로 인증해 데이터를 저장하는 로직은 그대로 두고, `guestMode` 값은 `firebase` 컬렉션 선택과 쿠키 `postId` 저장 로직에 사용되도록 구현해둔 상태입니다. 코드 일관성을 위해 하나로 통일하는 것이 좋을지. 지금처럼 혼용해서 사용해도 괜찮을지, 아니면 더 좋은 방법이 없을지 고민이 되어서 금요일에 같이 이야기 나눠보면 좋을 것 같습니다.
2. result 페이지에서 이미지 백그라운드 처리 중 화면에 '이미지 최적화 중...' 텍스트가 보이긴 하는데 시각적으로 딱딱한 것 같아서 UI 개편을 고려해봐야 할 것 같습니다.