### PR TITLE
refactor: isMobile 대신 tailwindCSS 코드로 변경

### DIFF
--- a/src/components/ui/button/button.tsx
+++ b/src/components/ui/button/button.tsx
@@ -13,16 +13,12 @@ export interface ButtonProps {
 export const Button = ({
   children,
   label,
-  // 버튼의 기본 스타일을 고려했을 때 transparent가 기본적인 bgColor로 입력되기 때문에, main은 따로 입력값으로 넣어주게 의도하는게 좋을 것 같습니다.
   bgColor = 'transparent',
   disabled,
   className,
   ...props
 }: ButtonProps) => {
   const ariaLabel = typeof children === 'string' ? children : label;
-
-  // 여러가지 분기처리가 되어 선언적으로 스타일을 적용할 수 있게 잘 짜주셨는데, 만약 유지보수를 위해 코드를 고쳐야하는 상황이라면 해당 코드가 가독성이 안좋을 수 있다는 생각을 했습니다.
-  // 따라서 코드를 쪼개어 개발자가 세세하게 스타일을 들여다보지 않고 선언적인 키워드로 스타일을 적용할 수 있도록 구분해보았습니다.
 
   // 기본 스타일
   const baseStyles =
@@ -32,7 +28,7 @@ export const Button = ({
   const bgColorStyles = {
     transparent: 'ml-auto opacity-70',
     underline:
-      'text-main border-solid border-b border-main bg-transparent hover:text-main-hover',
+      'rounded-none text-main border-solid border-b border-main bg-transparent hover:text-main-hover',
     main: !disabled ? 'bg-main hover:bg-main-hover' : '',
     sub: !disabled ? 'bg-sub hover:bg-sub-hover' : '',
     white: !disabled ? 'bg-white hover:bg-white-hover text-black' : '',

--- a/src/components/ui/header.tsx
+++ b/src/components/ui/header.tsx
@@ -5,12 +5,10 @@ import { Text } from './text';
 import { useAuth } from '../../contexts/auth-context';
 import { auth } from '../../firebase';
 import { signOut } from 'firebase/auth';
-import { useMediaQuery } from 'usehooks-ts';
 import { FlexBox } from './flexbox';
 import { useGuestMode } from '../../hooks/use-guest-mode';
 
 export const Header = () => {
-  const isMobile = useMediaQuery('(max-width: 768px)');
   const navigate = useNavigate();
   const { currentUser } = useAuth();
   const [_, setGuestMode] = useGuestMode();
@@ -30,24 +28,23 @@ export const Header = () => {
 
   return (
     <header className='w-full flex justify-between items-center py-5 px-12'>
-      {/* Text를 isMobile마다 조건부로 스타일을 주어야하는 로직이 계속 보이는데 아예 Text안에서 isMobile일 경우 조정을 해보는 것은 어떨까요? */}
-      <Text fontSize={isMobile ? 'md' : 'lg'} fontWeight='bold'>
+      <Text fontSize='md' desktopFontSize='lg' fontWeight='bold'>
         AI 이상형 찾기
       </Text>
       <FlexBox className='items-center'>
         {currentUser ? (
           <>
             <Button bgColor='white' label='로그아웃' onClick={handleLogout}>
-              <Text fontSize={isMobile ? 'xs' : 'sm'} color='black'>
+              <Text fontSize='xs' desktopFontSize='sm' color='black'>
                 로그아웃
               </Text>
             </Button>
-            <Text className='mx-3' fontSize={isMobile ? 'xs' : 'sm'}>
+            <Text className='mx-3' fontSize='xs' desktopFontSize='sm'>
               |
             </Text>
             <Link to='/mypage'>
               <Button bgColor='white' label='마이페이지'>
-                <Text fontSize={isMobile ? 'xs' : 'sm'} color='black'>
+                <Text fontSize='xs' desktopFontSize='sm' color='black'>
                   마이페이지
                 </Text>
               </Button>
@@ -56,7 +53,8 @@ export const Header = () => {
         ) : (
           <Button bgColor='white' label='로그인' onClick={() => navigate('/')}>
             <Text
-              fontSize={isMobile ? 'xs' : 'sm'}
+              fontSize='xs'
+              desktopFontSize='sm'
               fontWeight='bold'
               color='black'
             >

--- a/src/components/ui/main.tsx
+++ b/src/components/ui/main.tsx
@@ -1,33 +1,16 @@
 import React from 'react';
-import clsx from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
 interface MainProps {
-  isMobile?: boolean;
   className?: string;
   children: React.ReactNode;
 }
 
-export const Main = ({ isMobile = false, className, children }: MainProps) => {
-  // Main을 이 프로젝트 전체의 Layout으로 잡으셨는데, 이럴 경우에는 isMobile을 props로 받는것보다 내부에서 isMobile을 판단해보는게 어떨까요?
-  // 그렇게 된다면 개발자가 일일히 props로 isMobile을 넘겨줄 필요가 없으니 더 편해질 것 같습니다.
-  // 이곳에는 clsx와 twMerge를 동시에 사용하지 말고 하나만 사용해도 충분할 것 같습니다.
-
+export const Main = ({ className, children }: MainProps) => {
   return (
     <main
       className={twMerge(
-        'flex items-center justify-center min-h-screen bg-white p-4',
-        isMobile ? 'flex-col gap-6' : 'gap-24',
-      )}
-    >
-      {children}
-    </main>
-  );
-  return (
-    <main
-      className={clsx(
-        'flex items-center justify-center min-h-screen bg-white p-4',
-        isMobile ? 'flex-col gap-6' : 'gap-24',
+        'flex flex-col gap-6 md:gap-24 items-center justify-center min-h-screen bg-white p-4',
         className,
       )}
     >

--- a/src/components/ui/text.tsx
+++ b/src/components/ui/text.tsx
@@ -4,6 +4,7 @@ import { twMerge } from 'tailwind-merge';
 
 export interface TextProps {
   fontSize?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
+  desktopFontSize?: 'xs' | 'sm' | 'md' | 'lg';
   fontWeight?: 'normal' | 'bold' | 'medium' | 'light';
   color?: 'black' | 'red' | 'white' | 'main';
   className?: string;
@@ -26,6 +27,16 @@ const fontSizeMap: Record<NonNullable<TextProps['fontSize']>, string> = {
   xxl: 'text-4xl', // 36px
 };
 
+const desktopFontSizeMap: Record<
+  NonNullable<TextProps['desktopFontSize']>,
+  string
+> = {
+  xs: 'md:text-xs',
+  sm: 'md:text-base',
+  md: 'md:text-lg',
+  lg: 'md:text-2xl',
+};
+
 const fontWeightMap: Record<NonNullable<TextProps['fontWeight']>, string> = {
   normal: 'font-normal',
   bold: 'font-bold',
@@ -35,14 +46,19 @@ const fontWeightMap: Record<NonNullable<TextProps['fontWeight']>, string> = {
 
 export const Text = ({
   fontSize = 'md',
+  desktopFontSize,
   fontWeight = 'normal',
   color = 'black',
   className,
   children,
 }: TextProps) => {
   const baseStyles = 'leading-normal';
+  const responsiveFontSize = desktopFontSize
+    ? `${fontSizeMap[fontSize]} ${desktopFontSizeMap[desktopFontSize]}`
+    : fontSizeMap[fontSize];
+
   const conditionalStyles = clsx(
-    fontSizeMap[fontSize],
+    responsiveFontSize,
     fontWeightMap[fontWeight],
     colorMap[color],
   );

--- a/src/hooks/use-responsive.ts
+++ b/src/hooks/use-responsive.ts
@@ -1,7 +1,0 @@
-import { useMediaQuery } from "usehooks-ts";
-
-export const useResponsive = () => {
-  const isMobile = useMediaQuery("(max-width: 768px)");
-
-  return isMobile;
-};

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -20,7 +20,7 @@ import { ErrorMessage } from '../components/ui/error-message';
 
 const loginSchema = z.object({
   email: z.string().email('이메일 형식이 올바르지 않습니다.'),
-  password: z.string().min(6, '비밀번호는 최소 8자 이상이어야 합니다.'),
+  password: z.string().min(8, '비밀번호는 최소 8자 이상이어야 합니다.'),
 });
 
 type LoginFormValues = z.infer<typeof loginSchema>;

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -8,7 +8,6 @@ import { ButtonGroup } from '../components/ui/button/button-group';
 import { FlexBox } from '../components/ui/flexbox';
 import { Text } from '../components/ui/text';
 import { FirebaseError } from 'firebase/app';
-import { useResponsive } from '../hooks/use-responsive';
 import FindPasswordModal from '../components/functional/find-password-modal';
 import NavigateToSurvey from '../components/functional/navigate-to-survey-props';
 import { loginWithGoogle } from '../services/auth/login-with-google';
@@ -21,22 +20,21 @@ import { ErrorMessage } from '../components/ui/error-message';
 
 const loginSchema = z.object({
   email: z.string().email('이메일 형식이 올바르지 않습니다.'),
-  password: z.string().min(8, '비밀번호는 최소 8자 이상이어야 합니다.')
-})
+  password: z.string().min(6, '비밀번호는 최소 8자 이상이어야 합니다.'),
+});
 
 type LoginFormValues = z.infer<typeof loginSchema>;
 
 const Home = () => {
   const navigate = useNavigate();
-  const isMobile = useResponsive();
   const [isModalOpen, setModalOpen] = useState(false);
   const [_, setGuestMode] = useGuestMode();
   const {
     register,
     handleSubmit,
-    formState: { errors }
+    formState: { errors },
   } = useForm<LoginFormValues>({
-    resolver: zodResolver(loginSchema)
+    resolver: zodResolver(loginSchema),
   });
 
   const { setCurrentUser } = useAuth();
@@ -78,54 +76,54 @@ const Home = () => {
   };
 
   return (
-    <Main isMobile={isMobile}>
-        <FlexBox direction='column' gap='md'>
-          <FlexBox direction='column' gap='xs' className='items-start w-full'>
-            <Text fontSize='lg' fontWeight='bold'>
-              안녕하세요!
-            </Text>
-            <Text fontSize='md' fontWeight='bold'>
-              나만의 이상형을 찾아 볼까요?
-            </Text>
-          </FlexBox>
-          <FlexBox direction='column' gap='sm'>
-            <Input
-              name='email'
-              type='email'
-              placeholder='이메일을 입력해주세요'
-              register={register}
-            />
-            <Input
-              type='password'
-              name='password'
-              placeholder='비밀번호를 입력해주세요'
-              register={register}
-            />
-          </FlexBox>
-          {errors.email ? (
-            <ErrorMessage message={errors.email?.message} />
-          ) : (
-            <ErrorMessage message={errors.password?.message} />
-          )}
-          <Button
-            bgColor='transparent'
-            className='p-0'
-            onClick={() => {
-              setModalOpen(true);
-            }}
-          >
-            비밀번호 찾기
-          </Button>
-          <Button
-            bgColor='main'
-            label='로그인하기'
-            className='w-full'
-            onClick={handleSubmit(onSubmit)}
-          >
-            로그인하기
-          </Button>
-          <NavigateToSurvey label='로그인 없이 시작'/>
+    <Main>
+      <FlexBox direction='column' gap='md'>
+        <FlexBox direction='column' gap='xs' className='items-start w-full'>
+          <Text fontSize='lg' fontWeight='bold'>
+            안녕하세요!
+          </Text>
+          <Text fontSize='md' fontWeight='bold'>
+            나만의 이상형을 찾아 볼까요?
+          </Text>
         </FlexBox>
+        <FlexBox direction='column' gap='sm'>
+          <Input
+            name='email'
+            type='email'
+            placeholder='이메일을 입력해주세요'
+            register={register}
+          />
+          <Input
+            type='password'
+            name='password'
+            placeholder='비밀번호를 입력해주세요'
+            register={register}
+          />
+        </FlexBox>
+        {errors.email ? (
+          <ErrorMessage message={errors.email?.message} />
+        ) : (
+          <ErrorMessage message={errors.password?.message} />
+        )}
+        <Button
+          bgColor='transparent'
+          className='p-0'
+          onClick={() => {
+            setModalOpen(true);
+          }}
+        >
+          비밀번호 찾기
+        </Button>
+        <Button
+          bgColor='main'
+          label='로그인하기'
+          className='w-full'
+          onClick={handleSubmit(onSubmit)}
+        >
+          로그인하기
+        </Button>
+        <NavigateToSurvey label='로그인 없이 시작' />
+      </FlexBox>
       <FlexBox direction='column' gap='xl'>
         <div>
           <Text fontSize='md' className='mb-3 text-center'>

--- a/src/pages/result.tsx
+++ b/src/pages/result.tsx
@@ -12,7 +12,6 @@ import { Main } from '../components/ui/main';
 import { doc, setDoc, getDoc } from 'firebase/firestore';
 import { db } from '../firebase';
 import { Header } from '../components/ui/header';
-import { useResponsive } from '../hooks/use-responsive';
 import { convertToWebP } from '../components/functional/convert-to-webp';
 import { uploadImageToFirebase } from '../services/upload-image-to-firebase';
 import { getCountAndTimeLeft, incrementCount } from '../services/count-service';
@@ -55,7 +54,6 @@ const Result = () => {
   const [isProcessing, setIsProcessing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const { currentUser } = useAuth();
-  const isMobile = useResponsive();
   const navigate = useNavigate();
 
   const isGuest = getCookie(COOKIE_NAMES.GUEST_MODE) === true;
@@ -254,7 +252,7 @@ const Result = () => {
         </Text>
         <Text>당신의 AI 이상형은 {profile?.occupation}입니다!</Text>
       </FlexBox>
-      <Main isMobile={isMobile}>
+      <Main>
         <PreventDefaultWrapper>
           <FlexBox direction='column'>
             <Picture imageUrl={imageUrl} altText='이상형 이미지' />


### PR DESCRIPTION
## #️⃣연관된 이슈

> #150

## 📝작업 내용

- Main 컴포넌트 사용 시, isMobile을 props로 받지 않고 컴포넌트안에서 tailwind 코드로 반응형 적용했습니다.
- use-responsive.ts 삭제했습니다.
- 홈페이지에서 가입하기 버튼 밑줄에 라운드가 들어있어서 underline button: border-radius none으로 수정했습니다.

## 💬리뷰 요구사항(선택)

> text 컴포넌트는 매번 뷰포트 크기에 따라 사이즈가 바뀌는 것은 아니기 때문에 isMobile을 대체하는 것에 고민이 있었습니다. tailwind는 기본적으로 모바일 크기로 반응형 코드를 제공하기 때문에 props로 `desktopFontSize`을 추가하여 전달하는 방식으로 변경했습니다. 혹시 다른 방법이 있다면 공유 부탁드립니다!