### PR TITLE
Fix: 마이페이지 조건부 훅 호출 에러 해결

### DIFF
--- a/src/components/utils/post-migration.ts
+++ b/src/components/utils/post-migration.ts
@@ -39,13 +39,9 @@ export const handleGuestPostMigration = async (
 
         // POST_ID 쿠키 삭제
         removeCookie(COOKIE_NAMES.POST_ID);
-      } else {
-        console.log('anonymous 문서가 존재하지 않음');
       }
     } catch (error) {
-      console.error('게스트 포스트 이전 중 오류 발생:', error);
+      console.error('포스트 이전 중 오류 발생:', error);
     }
-  } else {
-    console.log('게스트 포스트 ID가 없음');
   }
 };

--- a/src/pages/mypage.tsx
+++ b/src/pages/mypage.tsx
@@ -1,14 +1,12 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { doc, getDoc } from 'firebase/firestore';
 import { useAuth } from '../contexts/auth-context';
-import { useNavigate } from 'react-router-dom';
+import { Navigate, useNavigate } from 'react-router-dom';
 import NavigateToSurvey from '../components/functional/navigate-to-survey-props';
 import { Text } from '../components/ui/text';
 import { FlexBox } from '../components/ui/flexbox';
 import { GridBox } from '../components/ui/gridbox';
 import { Card } from '../components/ui/card/card';
 import { Main } from '../components/ui/main';
-import { db } from '../firebase';
 import { Header } from '../components/ui/header';
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import { CardContent } from '../components/ui/card/card-content';
@@ -22,6 +20,14 @@ const MyPage = () => {
   const navigate = useNavigate();
   const observer = useRef<IntersectionObserver | null>(null);
 
+  // 인증 상태 변경 감지
+  useEffect(() => {
+    if (!currentUser) {
+      alert('로그인이 필요한 서비스입니다. 홈으로 이동합니다.');
+    }
+  }, [currentUser]);
+
+  // 쿼리 로직
   const {
     data: userData,
     isLoading: isUserDataLoading,
@@ -48,6 +54,7 @@ const MyPage = () => {
     enabled: !!userData,
   });
 
+  // Intersection Observer 설정
   useEffect(() => {
     const loadMore = (entries: IntersectionObserverEntry[]) => {
       if (entries[0].isIntersecting && hasNextPage) {
@@ -60,12 +67,12 @@ const MyPage = () => {
     }
 
     observer.current = new IntersectionObserver(loadMore, {
-      root: null, // 뷰포트를 기준으로 함
+      root: null,
       rootMargin: '0px',
-      threshold: 1.0, // 100% 가시성이 있어야 트리거
+      threshold: 1.0,
     });
 
-    const target = document.getElementById('infinityQueryTrigger'); // 추가할 엘리먼트의 ID
+    const target = document.getElementById('infinityQueryTrigger');
     if (target) {
       observer.current.observe(target);
     }
@@ -87,10 +94,9 @@ const MyPage = () => {
     }
   };
 
+  // 조건부 렌더링
   if (!currentUser) {
-    alert('로그인이 필요한 서비스입니다. 홈으로 이동합니다.');
-    navigate('/');
-    return null;
+    return <Navigate to='/' replace />;
   }
 
   if (isUserDataLoading || isPostsLoading) {
@@ -103,6 +109,7 @@ const MyPage = () => {
 
   const posts = postsData?.pages.flatMap((page) => page?.posts) || [];
 
+  // 나머지 return 부분은 그대로 유지
   return (
     <>
       <Header />

--- a/src/pages/mypage.tsx
+++ b/src/pages/mypage.tsx
@@ -109,7 +109,6 @@ const MyPage = () => {
 
   const posts = postsData?.pages.flatMap((page) => page?.posts) || [];
 
-  // 나머지 return 부분은 그대로 유지
   return (
     <>
       <Header />

--- a/src/services/auth/login-with-google.ts
+++ b/src/services/auth/login-with-google.ts
@@ -25,11 +25,7 @@ export const loginWithGoogle = async () => {
     if (!userDoc.exists()) {
       // 문서가 존재하지 않으면, 새로운 유저 -> 저장
       await saveUserInfo(uid, email, nickname);
-      console.log('신규 유저 저장 완료');
-    } else {
-      // 이미 있는 유저 → 저장 안 함
-      console.log('기존 유저, 저장 생략');
-    }
+    } // 기존 유저 -> 저장 생략
 
     await handleGuestPostMigration(user);
     return credential;
@@ -43,7 +39,6 @@ export const handleRedirectResult = async () => {
     const result = await getRedirectResult(auth);
     if (result) {
       await handleGuestPostMigration(result.user);
-      console.log('getRedirectResult result: ', result);
       return result;
     }
     return null;

--- a/src/services/auth/logout.ts
+++ b/src/services/auth/logout.ts
@@ -5,7 +5,6 @@ export const logout = async () => {
   try {
     if (confirm('로그아웃 하시겠습니까?')) {
       await signOut(auth);
-      console.log('User logged out');
     }
   } catch (error) {
     console.error('Failed to logout with email: ', error);


### PR DESCRIPTION
## 📝작업 내용

> 마이페이지에서 로그아웃 시 곧바로 홈으로 리다이렉트되지 않고 새로고침해야 하는 버그를 해결했습니다. 불필요한 `console.log` 디버깅 코드를 제거했습니다.

### 문제 상황

![image](https://github.com/user-attachments/assets/fa6325b9-45a0-44c6-8bdb-e3b499e4c50e)
- 마이페이지에서 로그아웃 시, 콘솔창 에러와 함께 홈으로 곧바로 리다이렉트되지 않는 버그가 있었습니다.
- 마이페이지 컴포넌트가 렌더링되는 도중에`BrowserRouter`의 상태를 업데이트하려고 시도했기 때문에 에러가 발생했습니다.

### 원인
- React는 한 컴포넌트의 렌더링 중에 다른 컴포넌트의 상태를 변경하는 것을 허용하지 않습니다.
- 마이페이지 컴포넌트 조건부 렌더링 도중 인증 상태가 변경되어 라우팅을 변경하려고 했기 때문에 발생한 문제입니다.

### 해결 방법

#### 1. 첫 번째 시도 (해결 실패 ❌)

**[시도한 코드]**

```javascript
useEffect(() => {
  if (!currentUser) {
    alert('로그인이 필요한 서비스입니다. 홈으로 이동합니다.');
    navigate('/');
  }
}, [currentUser]);
```

**[발생한 문제]**

`useEffect` 훅 내부에서 `alert`과 `navigate`를 모두 실행하는 방식을 채택했으나 다음과 같은 에러가 발생했습니다.

![image](https://github.com/user-attachments/assets/226556b5-24b6-4757-82f4-5454d6c69df3)
![image](https://github.com/user-attachments/assets/589180ee-8f31-4243-9518-9182a8fa8876)

**[문제 원인]**

에러 메시지를 분석해보면 이전 렌더링에서 호출된 hooks 보다 현재 렌더링에서 hooks가 더 많이 호출된 결과로 발생한 에러임을 알 수 있습니다. 리액트에서 hooks는 매 렌더링마다 동일한 호출을 보장받아야 합니다. 

리액트의 `useEffect`는 렌더링 이후에 실행되므로, 초기 렌더링이 한 번 발생한 후에 `useEffect` 내 로직이 실행됩니다. 즉, `currentUser`가 `null` 이더라도 마이페이지 컴포넌트가 한 번 렌더링된 후 `useEffect` 내부에서 `navigate`로 페이지 이동을 시도하기 때문에 이미 api 호출과 쿼리 실행이 이루어진 상태가 됩니다. 따라서 마이페이지 컴포넌트의 불필요한 렌더링과 불필요한 api 호출이 발생합니다.

#### 2. 두 번째 시도 (해결 ✅)

앞서 발생한 문제를 해결하기 위해 조건부 렌더링을 활용했습니다. 

```javascript
  // useEffect 내에서는 alert만 처리
  useEffect(() => {
    if (!currentUser) {
      alert('로그인이 필요한 서비스입니다. 홈으로 이동합니다.');
    }
  }, [currentUser]);

...

  // 조건부 렌더링 - currentUser가 null이면 즉시 렌더링을 중단하고 Navigate 반환
  if (!currentUser) {
    return <Navigate to='/' replace />;
  }

  // currentUser가 있을 경우 아래 코드들 실행

```

이러한 흐름으로 코드를 작성하면 초기 컴포넌트 렌더링 시 `currentUser` 유무를 판단해 없을 경우 렌더링을 중단하고 즉시 홈으로 리다이렉트되기 때문에 불필요한 나머지 렌더링과 api 호출, 쿼리 실행이 발생하지 않게 됩니다.

#### 추가 설명

코멘트에 남겨주신 `useEffect` 내에 `return` 문을 작성하는 방법은 컴파일 에러가 발생합니다. `useEffect` 내부에서 JSX 반환이 불가능하기 때문입니다.

> 참고자료
https://velog.io/@sinf/Rendered-more-hooks-than-during-the-previous-render
https://nno3onn.tistory.com/entry/React-Error-Rendered-more-hooks-than-during-the-previous-render