### PR TITLE
Fix: 프롬프트 개선(무쌍, 밝은피부, 옷)

### DIFF
--- a/src/components/utils/survey.ts
+++ b/src/components/utils/survey.ts
@@ -1,6 +1,6 @@
 export type SurveyTypes = {
   question: string;
-  options: {[key: string]: string}[];
+  options: { [key: string]: string }[];
 };
 
 // 성별이 여자인 경우 설문내용
@@ -8,80 +8,113 @@ export const surveyContentsWomen: SurveyTypes[] = [
   {
     question: '원하는 연령대를 골라주세요',
     options: [
-      {label: '20대', value: '20s'},
-      {label: '30대', value: '30s'},
-      {label: '40대', value: '40s'},
-      {label: '50대 이상', value: '50s and over'},
+      { label: '20대', value: '20s' },
+      { label: '30대', value: '30s' },
+      { label: '40대', value: '40s' },
+      { label: '50대 이상', value: '50s and over' },
     ],
   },
   {
     question: '원하는 체형을 골라주세요',
     options: [
-      {label: '마른 체형', value: 'slim'},
-      {label: '통통한 체형', value: 'chubby'},
-      {label: '근육질 체형', value: 'muscular'},
-      {label: '상관 없음', value: 'average body'},
+      { label: '마른 체형', value: 'slim' },
+      { label: '통통한 체형', value: 'chubby' },
+      { label: '근육질 체형', value: 'muscular' },
+      { label: '상관 없음', value: 'average body' },
     ],
   },
   {
     question: '원하는 얼굴형을 골라주세요',
     options: [
-      {label: '둥근형', value: 'round face'},
-      {label: '계란형', value: 'oval face'},
-      {label: '각진형', value: 'angular face'},
-      {label: '상관 없음', value: 'natural face'},
+      { label: '둥근형', value: 'round face' },
+      { label: '계란형', value: 'oval face' },
+      { label: '각진형', value: 'angular face' },
+      { label: '상관 없음', value: 'natural face' },
     ],
   },
   {
     question: '원하는 피부색을 골라주세요',
     options: [
-      {label: '밝고 환한 밀크 톤', value: 'bright milk skin'},
+      {
+        label: '밝고 환한 밀크 톤',
+        value: 'porcelain white with no visible tan or shadow',
+      },
       {
         label: '자연스러운 미디엄 다크 톤',
         value: 'natural medium dark skin',
       },
-      {label: '태닝한 듯 건강한 다크 톤', value: 'tanned dark skin'},
-      {label: '상관 없음', value: 'natural skin tone'},
+      { label: '태닝한 듯 건강한 다크 톤', value: 'tanned dark skin' },
+      { label: '상관 없음', value: 'natural skin tone' },
     ],
   },
   {
     question: '원하는 눈 모양을 골라주세요',
     options: [
-      {label: '매력만점 무쌍', value: 'monolid eyes'},
-      {label: '자연스러운 속쌍', value: 'double eyelid eyes'},
-      {label: '쌍커풀 짙은 큰 눈', value: 'deep double eyelid eyes'},
-      {label: '상관 없음', value: 'simple eyes'},
+      {
+        label: '매력만점 무쌍',
+        value:
+          'almond-shaped monolid eyes with smooth eyelids and absolutely no visible crease above the eyes. Avoid any eyelid folds or creases',
+      },
+      {
+        label: '자연스러운 속쌍',
+        value:
+          'light double eyelid that naturally enhances eyes with a soft, barely noticeable crease',
+      },
+      {
+        label: '쌍커풀 짙은 큰 눈',
+        value:
+          'prominent and deep double eyelid eyes, clearly visible even when eyes are open',
+      },
+      { label: '상관 없음', value: 'natural-looking eyes' },
     ],
   },
   {
     question: '원하는 머리 스타일을 골라주세요',
     options: [
-      {label: '시크한 여자 숏컷', value: 'short'},
-      {label: '귀여운 단발', value: 'bob'},
-      {label: '자연스러운 중단발', value: 'medium length'},
-      {label: '청순한 긴생머리', value: 'long straight'},
-      {label: '상관 없음', value: 'natural straight hair'},
+      { label: '시크한 여자 숏컷', value: 'chic short pixie cut' },
+      { label: '귀여운 단발', value: 'neat shoulder-length bob' },
+      {
+        label: '자연스러운 중단발',
+        value: 'natural medium-length layered hair',
+      },
+      { label: '청순한 긴생머리', value: 'long straight sleek hair' },
+      { label: '상관 없음', value: 'classic medium-length hair' },
     ],
   },
   {
     question: '원하는 머리 색을 골라주세요',
     options: [
-      {label: '자연스러운 게 최고! 흑발', value: 'black hair'},
-      {label: '초콜릿 같은 갈색 머리', value: 'brown hair'},
-      {label: '개성 있는 금발', value: 'blonde hair'},
-      {label: '강렬한 빨간머리', value: 'red hair'},
-      {label: '자유로운 영혼, 컬러풀 헤어', value: 'colorful hair'},
-      {label: '상관 없음', value: 'natural color hair'},
+      { label: '자연스러운 게 최고! 흑발', value: 'black hair' },
+      { label: '초콜릿 같은 갈색 머리', value: 'brown hair' },
+      { label: '개성 있는 금발', value: 'blonde hair' },
+      { label: '강렬한 빨간머리', value: 'red hair' },
+      { label: '자유로운 영혼, 컬러풀 헤어', value: 'colorful hair' },
+      { label: '상관 없음', value: 'natural color hair' },
     ],
   },
   {
-    question: '옷 스타일을 골라주세요',
+    question: '원하는 옷 스타일을 골라주세요',
     options: [
-      {label: '심플한 캐주얼룩', value: 'simple casual style'},
-      {label: '깔끔한 정장', value: 'suit'},
-      {label: '힙한 mz룩', value: 'hip hop style'},
-      {label: '편한 트레이닝복', value: 'sports style'},
-      {label: '상관 없음', value: 'simple casual style'},
+      {
+        label: '심플한 캐주얼룩',
+        value: 'a stylish yet casual outfit with no suits or blazers',
+      },
+      {
+        label: '깔끔한 정장',
+        value: 'professional business attire',
+      },
+      {
+        label: '힙한 mz룩',
+        value: 'trendy Korean Gen-Z streetwear with oversized fit',
+      },
+      {
+        label: '편한 트레이닝복',
+        value: 'stylish athletic wear',
+      },
+      {
+        label: '상관 없음',
+        value: 'neat casual wear',
+      },
     ],
   },
 ];
@@ -90,81 +123,116 @@ export const surveyContentsMen: SurveyTypes[] = [
   {
     question: '원하는 연령대를 골라주세요',
     options: [
-      {label: '20대', value: '20s'},
-      {label: '30대', value: '30s'},
-      {label: '40대', value: '40s'},
-      {label: '50대 이상', value: '50s and over'},
+      { label: '20대', value: '20s' },
+      { label: '30대', value: '30s' },
+      { label: '40대', value: '40s' },
+      { label: '50대 이상', value: '50s and over' },
     ],
   },
   {
     question: '원하는 체형을 골라주세요',
     options: [
-      {label: '마른 체형', value: 'slim'},
-      {label: '통통한 체형', value: 'chubby'},
-      {label: '근육질 체형', value: 'muscular'},
-      {label: '상관 없음', value: 'natural face'},
+      { label: '마른 체형', value: 'slim' },
+      { label: '통통한 체형', value: 'chubby' },
+      { label: '근육질 체형', value: 'muscular' },
+      { label: '상관 없음', value: 'natural face' },
     ],
   },
   {
     question: '원하는 얼굴형을 골라주세요',
     options: [
-      {label: '둥근형', value: 'round face'},
-      {label: '계란형', value: 'oval face'},
-      {label: '각진형', value: 'angular face'},
-      {label: '상관 없음', value: 'natural face'},
+      { label: '둥근형', value: 'round face' },
+      { label: '계란형', value: 'oval face' },
+      { label: '각진형', value: 'angular face' },
+      { label: '상관 없음', value: 'natural face' },
     ],
   },
   {
     question: '원하는 피부색을 골라주세요',
     options: [
-      {label: '밝고 환한 밀크 톤', value: 'bright milk skin'},
+      {
+        label: '밝고 환한 밀크 톤',
+        value: 'porcelain white with no visible tan or shadow',
+      },
       {
         label: '자연스러운 미디엄 다크 톤',
         value: 'natural medium dark skin',
       },
-      {label: '태닝한 듯 건강한 다크 톤', value: 'tanned dark skin'},
-      {label: '상관 없음', value: 'natural skin tone'},
+      { label: '태닝한 듯 건강한 다크 톤', value: 'tanned dark skin' },
+      { label: '상관 없음', value: 'natural skin tone' },
     ],
   },
   {
     question: '원하는 눈 모양을 골라주세요',
     options: [
-      {label: '매력만점 무쌍', value: 'monolid eyes'},
-      {label: '자연스러운 속쌍', value: 'double eyelid eyes'},
-      {label: '쌍커풀 짙은 큰 눈', value: 'deep double eyelid eyes'},
-      {label: '상관 없음', value: 'simple eyes'},
+      {
+        label: '매력만점 무쌍',
+        value: 'monolid eyes. Avoid any eyelid folds or creases',
+      },
+      {
+        label: '자연스러운 속쌍',
+        value:
+          'light double eyelid that naturally enhances eyes with a soft, barely noticeable crease',
+      },
+      {
+        label: '쌍커풀 짙은 큰 눈',
+        value:
+          'prominent and deep double eyelid eyes, clearly visible even when eyes are open',
+      },
+      { label: '상관 없음', value: 'natural-looking eyes' },
     ],
   },
   {
     question: '원하는 머리 스타일을 골라주세요',
     options: [
-      {label: '깔끔한 짧은 머리', value: 'short'},
-      {label: '덮은머리', value: 'with front bangs'},
-      {label: '한껏 꾸민 포마드', value: 'pompadour'},
-      {label: '뽀글이 펌', value: 'poppy perm'},
-      {label: '느낌 있는 장발', value: 'long'},
-      {label: '상관 없음', value: 'natural straight hair'},
+      {
+        label: '깔끔한 짧은 머리',
+        value: 'clean short haircut with faded sides',
+      },
+      { label: '덮은머리', value: 'with front bangs' },
+      {
+        label: '한껏 꾸민 포마드',
+        value: 'classic pompadour with sleek sides',
+      },
+      { label: '뽀글이 펌', value: 'trendy Korean wave perm' },
+      { label: '느낌 있는 장발', value: 'stylish long layered hair' },
+      { label: '상관 없음', value: 'classic short hair' },
     ],
   },
   {
     question: '원하는 머리 색을 골라주세요',
     options: [
-      {label: '자연스러운 게 최고! 흑발', value: 'black hair'},
-      {label: '초콜릿 같은 갈색 머리', value: 'brown hair'},
-      {label: '개성 있는 금발', value: 'blonde hair'},
-      {label: '강렬한 빨간머리', value: 'red hair'},
-      {label: '자유로운 영혼, 컬러풀 헤어', value: 'colorful hair'},
-      {label: '상관 없음', value: 'natural color hair'},
+      { label: '자연스러운 게 최고! 흑발', value: 'black hair' },
+      { label: '초콜릿 같은 갈색 머리', value: 'brown hair' },
+      { label: '개성 있는 금발', value: 'blonde hair' },
+      { label: '강렬한 빨간머리', value: 'red hair' },
+      { label: '자유로운 영혼, 컬러풀 헤어', value: 'colorful hair' },
+      { label: '상관 없음', value: 'natural color hair' },
     ],
   },
   {
     question: '원하는 옷 스타일을 골라주세요',
     options: [
-      {label: '심플한 캐주얼룩', value: 'simple casual style'},
-      {label: '깔끔한 정장', value: 'suit'},
-      {label: '힙한 mz룩', value: 'hip hop style'},
-      {label: '편한 트레이닝복', value: 'sports style'},
-      {label: '상관 없음', value: 'simple casual style'},
+      {
+        label: '심플한 캐주얼룩',
+        value: 'a stylish yet casual outfit with no suits or blazers',
+      },
+      {
+        label: '깔끔한 정장',
+        value: 'professional business attire',
+      },
+      {
+        label: '힙한 mz룩',
+        value: 'trendy Korean Gen-Z streetwear with oversized fit',
+      },
+      {
+        label: '편한 트레이닝복',
+        value: 'stylish athletic wear',
+      },
+      {
+        label: '상관 없음',
+        value: 'neat casual wear',
+      },
     ],
   },
 ];

--- a/src/pages/generate.tsx
+++ b/src/pages/generate.tsx
@@ -50,6 +50,7 @@ const Generate = () => {
             profile: parsedProfile,
             hashTags,
             prompts,
+            revisedPrompt: imageData.usedPrompt,
             postId: newPostId,
             isLoggedIn: !!currentUser,
           },

--- a/src/pages/result.tsx
+++ b/src/pages/result.tsx
@@ -38,6 +38,7 @@ interface PostData {
   profile: string;
   hashTags: string[];
   prompts: string[];
+  revisedPrompt: string;
   userId: string | null;
   email: string | null;
 }
@@ -51,6 +52,7 @@ const Result = () => {
     profile: initialProfile,
     hashTags,
     prompts,
+    revisedPrompt,
   } = location.state || {};
   const [imageUrl, setImageUrl] = useState(tempImageUrl);
   const [profile, setProfile] = useState<ProfileTypes | null>(initialProfile);
@@ -59,53 +61,49 @@ const Result = () => {
   const { currentUser } = useAuth();
   const navigate = useNavigate();
 
-  const isGuest = getGuestMode()
+  const isGuest = getGuestMode();
 
   const MotionLoader = motion.create(Loader2);
 
-  const fetchPostData = useCallback(
-    async (postId: string) => {
-      if (!postId) return;
+  const fetchPostData = useCallback(async (postId: string) => {
+    if (!postId) return;
 
-      try {
-        // posts 컬렉션 먼저 확인
-        let postRef = doc(db, 'posts', postId);
-        let postDoc = await getDoc(postRef);
-        
-        if (postDoc.exists()) {
-          const data = postDoc.data();
-          setImageUrl(data.imageUrl);
-          setProfile(
-            typeof data.profile === 'string'
-              ? JSON.parse(data.profile)
-              : data.profile,
-          );
-          return;
-        }
+    try {
+      // posts 컬렉션 먼저 확인
+      let postRef = doc(db, 'posts', postId);
+      let postDoc = await getDoc(postRef);
 
-        // posts에 없으면 anonymous_posts 확인
-        if (!postDoc.exists()) {
-          postRef = doc(db, 'anonymous_posts', postId);
-          postDoc = await getDoc(postRef);
-          return;
-        } 
-        
-
-        const savedData = localStorage.getItem(`result_${postId}`);
-        if (savedData) {
-          const parsedData = JSON.parse(savedData);
-          setImageUrl(parsedData.tempImageUrl);
-          setProfile(parsedData.profile);
-        } else {
-          setError('데이터를 찾을 수 없습니다.');
-        }
-      } catch (error) {
-        console.error('게시물 데이터 로딩 실패:', error);
-        setError('데이터를 불러오는데 실패했습니다.');
+      if (postDoc.exists()) {
+        const data = postDoc.data();
+        setImageUrl(data.imageUrl);
+        setProfile(
+          typeof data.profile === 'string'
+            ? JSON.parse(data.profile)
+            : data.profile,
+        );
+        return;
       }
-    },
-    [],  
-  );
+
+      // posts에 없으면 anonymous_posts 확인
+      if (!postDoc.exists()) {
+        postRef = doc(db, 'anonymous_posts', postId);
+        postDoc = await getDoc(postRef);
+        return;
+      }
+
+      const savedData = localStorage.getItem(`result_${postId}`);
+      if (savedData) {
+        const parsedData = JSON.parse(savedData);
+        setImageUrl(parsedData.tempImageUrl);
+        setProfile(parsedData.profile);
+      } else {
+        setError('데이터를 찾을 수 없습니다.');
+      }
+    } catch (error) {
+      console.error('게시물 데이터 로딩 실패:', error);
+      setError('데이터를 불러오는데 실패했습니다.');
+    }
+  }, []);
 
   // 초기 데이터 가져오기
   useEffect(() => {
@@ -124,7 +122,9 @@ const Result = () => {
         const actualPostId = postId;
 
         const postsDoc = await getDoc(doc(db, 'posts', actualPostId));
-        const anonymousDoc = await getDoc(doc(db, 'anonymous_posts', actualPostId));
+        const anonymousDoc = await getDoc(
+          doc(db, 'anonymous_posts', actualPostId),
+        );
 
         // 이미 저장된 데이터라면 early return
         if (postsDoc.exists() || anonymousDoc.exists()) {
@@ -151,6 +151,7 @@ const Result = () => {
           profile: profileToSave,
           hashTags: hashTags || [],
           prompts: prompts || [],
+          revisedPrompt: revisedPrompt || '',
           userId: currentUser?.uid || null,
           email: currentUser?.email || null,
         };
@@ -158,7 +159,10 @@ const Result = () => {
         // 컬렉션 결정
         const collectionToUse = isGuest ? 'anonymous_posts' : 'posts';
         await setDoc(doc(db, collectionToUse, actualPostId), postData);
-        console.log('데이터 저장 완료:', { postId: actualPostId, collection: collectionToUse });
+        console.log('데이터 저장 완료:', {
+          postId: actualPostId,
+          collection: collectionToUse,
+        });
 
         // 게스트 모드인 경우 쿠키에 postId 저장
         if (isGuest) {

--- a/src/services/image-generate.ts
+++ b/src/services/image-generate.ts
@@ -1,7 +1,7 @@
-import OpenAI from "openai";
+import OpenAI from 'openai';
 
 export const maxDuration = 300;
-export const dynamic = "force-dynamic";
+export const dynamic = 'force-dynamic';
 
 const openai = new OpenAI({
   apiKey: import.meta.env.VITE_OPEN_AI_API_KEY,
@@ -20,18 +20,42 @@ type orderType = {
   outfit: string;
 };
 
+function createPersonDescription(order: orderType) {
+  const pronoun = order.gender === 'man' ? 'He' : 'She';
+  const possessiveAdjective = order.gender === 'man' ? 'his' : 'her';
+
+  const intro = `Create a realistic and passport-style image of a Korean ${order.gender} in ${possessiveAdjective} ${order.age}. ${pronoun} should not be holding a passport`;
+
+  const eyes = `${pronoun} has ${order.eyesShape}.`;
+
+  const body = `${pronoun} has a ${order.bodyShape} physique.`;
+
+  const face = `${pronoun} has a ${order.faceShape} face with ${order.skinTone} skin tone.`;
+
+  const hair = `${pronoun} has ${order.hairStyle} styled hair in ${order.hairColor}.`;
+
+  const outfit = `${pronoun} is dressed in a well-fitted, perfectly coordinated ${order.outfit}. The clothing should be modern, trendy, and appropriate.`;
+
+  const background = `The image should be set against a plain light-colored background with soft, even lighting, creating a natural, polished, and refined look. There should be no visible passport in the image.`;
+
+  return `${intro} ${eyes} ${body} ${face} ${hair} ${outfit} ${background}`;
+}
+
 export async function imageGenerate(order: orderType) {
-  const prompt = `Create a realistic and passport-style image.  The subject is a Korean ${order.gender} in ${order.gender === "man" ? "his " : "her "} ${order.age} with a ${order.bodyShape} physique and a ${order.faceShape}. ${order.gender === "man" ? "He " : "She "} has ${order.skinTone}, distinguishing ${order.eyesShape}, and a ${order.hairStyle} cut with ${order.hairColor}. ${order.gender === "man" ? "He " : "She "} is wearing a ${order.outfit} outfit. The image is set against a plain light-colored background with soft lighting, exuding a natural, polished, and refined look`;
+  const prompt = createPersonDescription(order);
 
   try {
     const response = await openai.images.generate({
-      model: "dall-e-3",
+      model: 'dall-e-3',
       prompt: prompt,
       n: 1,
-      size: "1024x1024",
+      size: '1024x1024',
     });
 
-    return response?.data[0];
+    return {
+      ...response?.data[0],
+      usedPrompt: prompt, // 실제 사용된 프롬프트 추가
+    };
   } catch (err) {
     console.error(err);
   }


### PR DESCRIPTION
> 사용자 테스트 피드백을 개선하는 작업을 했습니다.
> - 밝은 피부 -> 구릿빛 피부로 나왔다.
> - 무쌍 -> 쌍꺼풀 있게 나왔다.
> - 옷차림 반영이 잘 안되는 것 같다.


## #️⃣연관된 이슈

> #197 

## 📝작업 내용
#### 1. postData에 revisedPrompt 추가하여 실제 프롬프트가 어떻게 넘겨졌는지 확인했습니다.
#### 2. 실제 데이터를 토대로 gpt에서 다시 생성 요청해봤고
#### 3. 어떤 부분을 모호하게 받아들이는지 확인 후, 더 구체적인 표현을 사용했고 원하지 않는 요소도 추가했습니다. (피부톤, 눈, 헤어, 옷 스타일)
#### 4. 최종적으로 요청하기 위한 프롬프트의 각 특성별로 구분하여 가독성있게 수정하였습니다.
#### 5. 가끔 여권을 들고 있는 사진이 보여서 해당 지문도 추가했습니다.
#### 6. 무쌍은 특히 여자의 경우에 반영하지 못하고 있었으며, DALL·E 3는 쌍꺼풀이 없는 특징을 완벽하게 반영하지 못하는 것 같습니다. 무쌍 연예인 이미지를 gpt에 제공하여 프롬프트를 작성해보게 하고 + 계속 프롬프트 수정해보며 최대한 결과물이 나오게끔 수정했습니다.

### [무쌍 프롬프트]
- 시도해본 프롬프트 키워드: `monolid eyes with no visible crease` / `no double eyelid...` / `smal/petite/narrow`...
- 개선된 프롬프트: ` almond-shaped monolid eyes with smooth eyelids and absolutely no visible crease above the eyes. Avoid any eyelid folds or creases`
-> 'absolutely', 'Avoid' 로 강조하여 명시하니 이전보다 반영되고 있습니다. 그래도 쌍꺼풀이 있는 눈을 만들어 낼 때가 있어서 'smooth eylids'를 추가하여 눈꺼풀이 선명하지 않게 하도록했습니다.


### 스크린샷 (선택)

[무쌍 개선 전후]
|Before|After|
|------|---|
|![image](https://github.com/user-attachments/assets/22aecbe1-6641-41cb-9fb0-ee5ba53eb7a8)|![image](https://github.com/user-attachments/assets/64eb1885-adc6-4a59-beac-ed8549bc1998)|


## 💬리뷰 요구사항(선택)

> @joshyeom 피부색을 코드로 넘겨봤더니 제대로 반영되지 못한 결과물이 나왔었습니다. gpt에 의하면 DALL·E 3는 코드보단 텍스트로 설명하는 것이 더 효과적이라고 합니다! 
> 개선 내용에 관해 다른 의견 공유해주시면 반영해보겠습니다:)